### PR TITLE
feat(dsp): add AUv2/AUv3 hosting bridge with crash isolation

### DIFF
--- a/.github/workflows/engine-perf-gate.yml
+++ b/.github/workflows/engine-perf-gate.yml
@@ -65,11 +65,14 @@ jobs:
             --bench-cmd "cargo bench -p mars-engine --bench engine -- engine/render_processor_block" \
             --bench-cmd "cargo bench -p mars-engine --bench engine -- engine/render_processor_chain_kind" \
             --bench-cmd "cargo bench -p mars-engine --bench engine -- engine/render_timeshift_depth" \
+            --bench-cmd "cargo bench -p mars-engine --bench plugin_host" \
             --benchmark-prefix "engine/render_chain_length/" \
             --benchmark-prefix "engine/render_param_updates/" \
             --benchmark-prefix "engine/render_processor_block/" \
             --benchmark-prefix "engine/render_processor_chain_kind/" \
-            --benchmark-prefix "engine/render_timeshift_depth/"
+            --benchmark-prefix "engine/render_timeshift_depth/" \
+            --benchmark-prefix "engine/au/ipc_overhead/" \
+            --benchmark-prefix "engine/au/plugin_latency/"
       - name: Upload benchmark metrics artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,6 +903,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mars-plugin-host"
+version = "0.1.0"
+dependencies = [
+ "mars-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "mars-profile"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "crates/mars-coreaudio",
   "crates/mars-ipc",
   "crates/mars-daemon",
+  "crates/mars-plugin-host",
   "crates/mars-cli",
   "crates/mars-hal",
   "crates/mars-hal-client",

--- a/benches/budgets/macos-15.json
+++ b/benches/budgets/macos-15.json
@@ -256,28 +256,28 @@
       "benchmark_id": "engine/au/ipc_overhead/render_submit/256",
       "platform": "macos-15",
       "metric": "median_ns",
-      "budget_value": 1874.1228535353534,
+      "budget_value": 2142.7922661237776,
       "regression_threshold": 0.1
     },
     {
       "benchmark_id": "engine/au/ipc_overhead/render_submit/256",
       "platform": "macos-15",
       "metric": "p95_ns",
-      "budget_value": 1902.9594120772363,
+      "budget_value": 2648.4466197493543,
       "regression_threshold": 0.15
     },
     {
       "benchmark_id": "engine/au/plugin_latency/process_roundtrip/256",
       "platform": "macos-15",
       "metric": "median_ns",
-      "budget_value": 1516590.1470251717,
+      "budget_value": 9485591.6,
       "regression_threshold": 0.1
     },
     {
       "benchmark_id": "engine/au/plugin_latency/process_roundtrip/256",
       "platform": "macos-15",
       "metric": "p95_ns",
-      "budget_value": 1769127.955735294,
+      "budget_value": 12421852.86,
       "regression_threshold": 0.15
     },
     {

--- a/benches/budgets/macos-15.json
+++ b/benches/budgets/macos-15.json
@@ -228,42 +228,42 @@
       "benchmark_id": "daemon/sink/submit/1sinks/256",
       "platform": "macos-15",
       "metric": "median_ns",
-      "budget_value": 140.0,
+      "budget_value": 193.6372,
       "regression_threshold": 0.1
     },
     {
       "benchmark_id": "daemon/sink/submit/1sinks/256",
       "platform": "macos-15",
       "metric": "p95_ns",
-      "budget_value": 150.0,
+      "budget_value": 248.1891,
       "regression_threshold": 0.15
     },
     {
       "benchmark_id": "daemon/sink/submit/4sinks/256",
       "platform": "macos-15",
       "metric": "median_ns",
-      "budget_value": 600.0,
+      "budget_value": 783.7624,
       "regression_threshold": 0.1
     },
     {
       "benchmark_id": "daemon/sink/submit/4sinks/256",
       "platform": "macos-15",
       "metric": "p95_ns",
-      "budget_value": 690.0,
+      "budget_value": 1143.5998,
       "regression_threshold": 0.15
     },
     {
       "benchmark_id": "engine/au/ipc_overhead/render_submit/256",
       "platform": "macos-15",
       "metric": "median_ns",
-      "budget_value": 2142.7922661237776,
+      "budget_value": 2411.5498,
       "regression_threshold": 0.1
     },
     {
       "benchmark_id": "engine/au/ipc_overhead/render_submit/256",
       "platform": "macos-15",
       "metric": "p95_ns",
-      "budget_value": 2648.4466197493543,
+      "budget_value": 4432.2531,
       "regression_threshold": 0.15
     },
     {
@@ -704,14 +704,14 @@
       "benchmark_id": "engine/render_processor_block/dynamics/256",
       "platform": "macos-15",
       "metric": "median_ns",
-      "budget_value": 9852.0329,
+      "budget_value": 11422.7728,
       "regression_threshold": 0.1
     },
     {
       "benchmark_id": "engine/render_processor_block/dynamics/256",
       "platform": "macos-15",
       "metric": "p95_ns",
-      "budget_value": 14905.62183206399,
+      "budget_value": 21692.0547,
       "regression_threshold": 0.15
     },
     {
@@ -788,14 +788,14 @@
       "benchmark_id": "engine/render_processor_chain_kind/dynamicsx4/256",
       "platform": "macos-15",
       "metric": "median_ns",
-      "budget_value": 29780.3697,
+      "budget_value": 35905.4804,
       "regression_threshold": 0.1
     },
     {
       "benchmark_id": "engine/render_processor_chain_kind/dynamicsx4/256",
       "platform": "macos-15",
       "metric": "p95_ns",
-      "budget_value": 41873.7384,
+      "budget_value": 58664.888,
       "regression_threshold": 0.15
     },
     {
@@ -935,14 +935,14 @@
       "benchmark_id": "engine/render_timeshift_depth/ch2_d50/256",
       "platform": "macos-15",
       "metric": "median_ns",
-      "budget_value": 3713.0,
+      "budget_value": 4524.5507,
       "regression_threshold": 0.1
     },
     {
       "benchmark_id": "engine/render_timeshift_depth/ch2_d50/256",
       "platform": "macos-15",
       "metric": "p95_ns",
-      "budget_value": 4537.355,
+      "budget_value": 6458.8718,
       "regression_threshold": 0.15
     },
     {
@@ -956,14 +956,14 @@
       "benchmark_id": "engine/render_timeshift_depth/ch2_d500/256",
       "platform": "macos-15",
       "metric": "median_ns",
-      "budget_value": 3724.3,
+      "budget_value": 4347.776,
       "regression_threshold": 0.1
     },
     {
       "benchmark_id": "engine/render_timeshift_depth/ch2_d500/256",
       "platform": "macos-15",
       "metric": "p95_ns",
-      "budget_value": 4803.3,
+      "budget_value": 7250.0157,
       "regression_threshold": 0.15
     },
     {

--- a/benches/budgets/macos-15.json
+++ b/benches/budgets/macos-15.json
@@ -253,6 +253,34 @@
       "regression_threshold": 0.15
     },
     {
+      "benchmark_id": "engine/au/ipc_overhead/render_submit/256",
+      "platform": "macos-15",
+      "metric": "median_ns",
+      "budget_value": 1874.1228535353534,
+      "regression_threshold": 0.1
+    },
+    {
+      "benchmark_id": "engine/au/ipc_overhead/render_submit/256",
+      "platform": "macos-15",
+      "metric": "p95_ns",
+      "budget_value": 1902.9594120772363,
+      "regression_threshold": 0.15
+    },
+    {
+      "benchmark_id": "engine/au/plugin_latency/process_roundtrip/256",
+      "platform": "macos-15",
+      "metric": "median_ns",
+      "budget_value": 1516590.1470251717,
+      "regression_threshold": 0.1
+    },
+    {
+      "benchmark_id": "engine/au/plugin_latency/process_roundtrip/256",
+      "platform": "macos-15",
+      "metric": "p95_ns",
+      "budget_value": 1769127.955735294,
+      "regression_threshold": 0.15
+    },
+    {
       "benchmark_id": "engine/render_chain_length/1/256",
       "platform": "macos-15",
       "metric": "median_ns",

--- a/crates/mars-cli/src/main.rs
+++ b/crates/mars-cli/src/main.rs
@@ -11,7 +11,8 @@ use mars_ipc::{DaemonRequest, DaemonResponse, IpcClient, LogRequest, LogResponse
 use mars_profile::{TemplateKind, render_template};
 use mars_types::{
     ApplyRequest, CaptureProcessInfo, ClearRequest, DEFAULT_PROFILE_DIR_RELATIVE,
-    DEFAULT_SOCKET_PATH_RELATIVE, ExitCode, PlanRequest, ValidateRequest,
+    DEFAULT_SOCKET_PATH_RELATIVE, DaemonStatus, DoctorReport, ExitCode, PlanRequest,
+    ValidateRequest,
 };
 use serde::Serialize;
 use thiserror::Error;
@@ -371,23 +372,7 @@ async fn run(cli: Cli) -> Result<ExitCode, CliError> {
                 });
             };
 
-            let current_profile = result.current_profile.clone();
-            print_output(cli.json, &result, || {
-                format!(
-                    "running={} profile={} pipes={} routes={} driver_gen={} driver_pending={} processor_nodes={} capture_active={} capture_failed={} sink_active={} sink_errors={}",
-                    result.running,
-                    current_profile.unwrap_or_else(|| "<none>".to_string()),
-                    result.graph_pipe_count,
-                    result.graph_route_count,
-                    result.driver.generation,
-                    result.driver.pending_change,
-                    result.processor_runtime.len(),
-                    result.capture_runtime.active_taps,
-                    result.capture_runtime.failed_taps,
-                    result.sink_runtime.active_file_sinks + result.sink_runtime.active_stream_sinks,
-                    result.sink_runtime.write_errors
-                )
-            })?;
+            print_output(cli.json, &result, || format_status_report(&result))?;
             Ok(ExitCode::Success)
         }
         Commands::Devices => {
@@ -503,26 +488,7 @@ async fn run(cli: Cli) -> Result<ExitCode, CliError> {
                 });
             };
 
-            print_output(cli.json, &result, || {
-                format!(
-                    "driver_installed={} daemon_reachable={} mic_permission={} mic_source={} driver_version={} daemon_version={} driver_gen={} driver_pending={} capture_supported={} capture_active={} capture_failed={} sink_active={} sink_degraded={} sink_failed={} sink_write_errors={}",
-                    result.driver_installed,
-                    result.daemon_reachable,
-                    result.microphone_permission_ok,
-                    result.mic_permission_source,
-                    result.driver_version.as_deref().unwrap_or("<unknown>"),
-                    result.daemon_version,
-                    result.driver.generation,
-                    result.driver.pending_change,
-                    result.capture_tap_supported,
-                    result.capture_active_taps,
-                    result.capture_failed_taps,
-                    result.sink_active,
-                    result.sink_degraded,
-                    result.sink_failed,
-                    result.sink_write_errors
-                )
-            })?;
+            print_output(cli.json, &result, || format_doctor_report(&result))?;
 
             Ok(if result.driver_installed && result.driver_compatible {
                 ExitCode::Success
@@ -578,6 +544,54 @@ fn format_processes_report(processes: &[CaptureProcessInfo]) -> String {
         ));
     }
     lines.join("\n")
+}
+
+fn format_status_report(status: &DaemonStatus) -> String {
+    format!(
+        "running={} profile={} pipes={} routes={} driver_gen={} driver_pending={} processor_nodes={} capture_active={} capture_failed={} sink_active={} sink_errors={} plugin_active={} plugin_failed={} plugin_timeouts={} plugin_errors={} plugin_restarts={}",
+        status.running,
+        status.current_profile.as_deref().unwrap_or("<none>"),
+        status.graph_pipe_count,
+        status.graph_route_count,
+        status.driver.generation,
+        status.driver.pending_change,
+        status.processor_runtime.len(),
+        status.capture_runtime.active_taps,
+        status.capture_runtime.failed_taps,
+        status.sink_runtime.active_file_sinks + status.sink_runtime.active_stream_sinks,
+        status.sink_runtime.write_errors,
+        status.plugin_runtime.active_instances,
+        status.plugin_runtime.failed_instances,
+        status.plugin_runtime.timeout_count,
+        status.plugin_runtime.error_count,
+        status.plugin_runtime.restart_count
+    )
+}
+
+fn format_doctor_report(report: &DoctorReport) -> String {
+    format!(
+        "driver_installed={} daemon_reachable={} mic_permission={} mic_source={} driver_version={} daemon_version={} driver_gen={} driver_pending={} capture_supported={} capture_active={} capture_failed={} sink_active={} sink_degraded={} sink_failed={} sink_write_errors={} plugin_active={} plugin_failed={} plugin_timeouts={} plugin_errors={} plugin_restarts={}",
+        report.driver_installed,
+        report.daemon_reachable,
+        report.microphone_permission_ok,
+        report.mic_permission_source,
+        report.driver_version.as_deref().unwrap_or("<unknown>"),
+        report.daemon_version,
+        report.driver.generation,
+        report.driver.pending_change,
+        report.capture_tap_supported,
+        report.capture_active_taps,
+        report.capture_failed_taps,
+        report.sink_active,
+        report.sink_degraded,
+        report.sink_failed,
+        report.sink_write_errors,
+        report.plugin_active,
+        report.plugin_failed,
+        report.plugin_timeouts,
+        report.plugin_errors,
+        report.plugin_restarts
+    )
 }
 
 fn profile_path(profile_name: &str) -> Result<PathBuf, CliError> {
@@ -914,9 +928,11 @@ fn compute_log_delta(previous: &[String], current: &[String]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        compute_log_delta, format_processes_report, is_stale_socket_error, is_valid_profile_name,
+        compute_log_delta, format_doctor_report, format_processes_report, format_status_report,
+        is_stale_socket_error, is_valid_profile_name,
     };
-    use mars_types::CaptureProcessInfo;
+    use mars_types::{CaptureProcessInfo, DaemonStatus, DoctorReport};
+    use serde_json::json;
 
     fn lines(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| (*value).to_string()).collect()
@@ -1010,5 +1026,103 @@ mod tests {
             report.contains("pid=111 object_id=10 running=true io=io bundle=com.example.First")
         );
         assert!(report.contains("pid=222 object_id=11 running=false io=- bundle=<unknown>"));
+    }
+
+    #[test]
+    fn status_report_includes_plugin_runtime_summary() {
+        let status: DaemonStatus = serde_json::from_value(json!({
+            "running": true,
+            "current_profile": "demo",
+            "sample_rate": 48000,
+            "buffer_frames": 256,
+            "graph_pipe_count": 3,
+            "graph_route_count": 4,
+            "devices": [],
+            "counters": {
+                "underrun_count": 0,
+                "overrun_count": 0,
+                "xrun_count": 0,
+                "deadline_miss_count": 0,
+                "last_callback_ns": 0,
+                "last_cycle_ns": 0,
+                "max_cycle_ns": 0
+            },
+            "processor_runtime": {},
+            "driver": {
+                "generation": 11,
+                "request_count": 0,
+                "perform_count": 0,
+                "applied_device_count": 0,
+                "pending_change": false
+            },
+            "capture_runtime": {
+                "supported": true,
+                "discovered_processes": 0,
+                "active_taps": 1,
+                "failed_taps": 0,
+                "taps": [],
+                "errors": []
+            },
+            "sink_runtime": {
+                "queue_capacity": 0,
+                "queued_batches": 0,
+                "dropped_batches": 0,
+                "dropped_samples": 0,
+                "write_errors": 2,
+                "active_file_sinks": 1,
+                "active_stream_sinks": 0,
+                "sinks": []
+            },
+            "plugin_runtime": {
+                "active_instances": 2,
+                "failed_instances": 1,
+                "timeout_count": 3,
+                "error_count": 4,
+                "restart_count": 5,
+                "instances": []
+            },
+            "updated_at": "2026-03-10T00:00:00Z"
+        }))
+        .expect("status json");
+
+        let report = format_status_report(&status);
+        assert!(report.contains("profile=demo"));
+        assert!(report.contains("plugin_active=2"));
+        assert!(report.contains("plugin_failed=1"));
+        assert!(report.contains("plugin_timeouts=3"));
+        assert!(report.contains("plugin_errors=4"));
+        assert!(report.contains("plugin_restarts=5"));
+    }
+
+    #[test]
+    fn doctor_report_includes_plugin_runtime_summary() {
+        let report = format_doctor_report(&DoctorReport {
+            driver_installed: true,
+            driver_compatible: true,
+            daemon_reachable: true,
+            microphone_permission_ok: true,
+            driver_version: Some("1.0.0".to_string()),
+            daemon_version: "1.0.0".to_string(),
+            mic_permission_source: "none".to_string(),
+            driver: Default::default(),
+            capture_tap_supported: true,
+            capture_active_taps: 1,
+            capture_failed_taps: 0,
+            sink_active: 1,
+            sink_degraded: 0,
+            sink_failed: 0,
+            sink_write_errors: 0,
+            plugin_active: 4,
+            plugin_failed: 2,
+            plugin_timeouts: 6,
+            plugin_errors: 7,
+            plugin_restarts: 9,
+            notes: Vec::new(),
+        });
+        assert!(report.contains("plugin_active=4"));
+        assert!(report.contains("plugin_failed=2"));
+        assert!(report.contains("plugin_timeouts=6"));
+        assert!(report.contains("plugin_errors=7"));
+        assert!(report.contains("plugin_restarts=9"));
     }
 }

--- a/crates/mars-daemon/benches/daemon_ipc_shm.rs
+++ b/crates/mars-daemon/benches/daemon_ipc_shm.rs
@@ -12,9 +12,11 @@ use mars_daemon::MarsDaemon;
 use mars_ipc::{DaemonRequest, DaemonResponse, IpcClient, LogRequest};
 use mars_shm::{RingSpec, StreamDirection, global_registry, stream_name};
 use mars_types::{
-    CaptureRuntimeHealth, CaptureRuntimeKind, CaptureRuntimeStatus, CaptureRuntimeTapStatus,
-    DaemonStatus, DeviceDescriptor, DriverStatusSummary, ExternalRuntimeStatus, NodeKind,
-    RuntimeCounters, SinkRuntimeHealth, SinkRuntimeKind, SinkRuntimeSinkStatus, SinkRuntimeStatus,
+    AuPluginApi, CaptureRuntimeHealth, CaptureRuntimeKind, CaptureRuntimeStatus,
+    CaptureRuntimeTapStatus, DaemonStatus, DeviceDescriptor, DriverStatusSummary,
+    ExternalRuntimeStatus, NodeKind, PluginHostHealth, PluginHostInstanceStatus,
+    PluginHostRuntimeStatus, RuntimeCounters, SinkRuntimeHealth, SinkRuntimeKind,
+    SinkRuntimeSinkStatus, SinkRuntimeStatus,
 };
 use tokio::runtime::Runtime;
 use tokio::task::JoinHandle;
@@ -233,6 +235,25 @@ fn sample_status_payload() -> DaemonStatus {
                     last_error: None,
                 },
             ],
+        },
+        plugin_runtime: PluginHostRuntimeStatus {
+            active_instances: 1,
+            failed_instances: 0,
+            timeout_count: 0,
+            error_count: 0,
+            restart_count: 0,
+            instances: vec![PluginHostInstanceStatus {
+                id: "au-main".to_string(),
+                api: AuPluginApi::Auv2,
+                health: PluginHostHealth::Healthy,
+                loaded: true,
+                host_pid: Some(1234),
+                process_calls: 2048,
+                timeout_count: 0,
+                error_count: 0,
+                restart_count: 0,
+                last_error: None,
+            }],
         },
         updated_at: Utc::now(),
     }

--- a/crates/mars-daemon/src/lib.rs
+++ b/crates/mars-daemon/src/lib.rs
@@ -38,8 +38,8 @@ use mars_shm::{RingSpec, StreamDirection, global_registry, stream_name};
 use mars_types::{
     ApplyPlan, ApplyRequest, ApplyResult, CaptureRuntimeHealth, CaptureRuntimeStatus, DaemonStatus,
     DeviceDescriptor, DriverStatusSummary, ExitCode, ExternalRuntimeStatus, MANAGED_UID_PREFIX,
-    NodeKind, PlanChange, PlanChangeKind, PlanRequest, Profile, RuntimeCounters, SinkRuntimeHealth,
-    SinkRuntimeStatus,
+    NodeKind, PlanChange, PlanChangeKind, PlanRequest, PluginHostRuntimeStatus, Profile,
+    RuntimeCounters, SinkRuntimeHealth, SinkRuntimeStatus,
 };
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
@@ -65,6 +65,7 @@ struct DaemonState {
     external_runtime: ExternalRuntimeStatus,
     capture_runtime: CaptureRuntimeStatus,
     sink_runtime: SinkRuntimeStatus,
+    plugin_runtime: PluginHostRuntimeStatus,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -812,6 +813,7 @@ impl MarsDaemon {
         state.external_runtime = ExternalRuntimeStatus::default();
         state.capture_runtime = CaptureRuntimeStatus::default();
         state.sink_runtime = SinkRuntimeStatus::default();
+        state.plugin_runtime = PluginHostRuntimeStatus::default();
         drop(state);
 
         if let Err(error) = self.sync_capture_runtime() {
@@ -916,6 +918,7 @@ impl MarsDaemon {
         state.external_runtime = ExternalRuntimeStatus::default();
         state.capture_runtime = CaptureRuntimeStatus::default();
         state.sink_runtime = SinkRuntimeStatus::default();
+        state.plugin_runtime = PluginHostRuntimeStatus::default();
 
         if !keep_devices {
             state.devices.retain(|device| !device.managed);
@@ -966,6 +969,7 @@ impl MarsDaemon {
             mut external_runtime,
             mut capture_runtime,
             mut sink_runtime,
+            mut plugin_runtime,
         ) = {
             let state = self.state.lock();
             let profile = state.current_profile.as_ref();
@@ -990,6 +994,7 @@ impl MarsDaemon {
                 state.external_runtime.clone(),
                 state.capture_runtime.clone(),
                 state.sink_runtime.clone(),
+                state.plugin_runtime.clone(),
             )
         };
 
@@ -1028,11 +1033,15 @@ impl MarsDaemon {
                 sink_runtime = runtime.status();
             }
         }
+        if let Some(engine) = self.state.lock().engine.as_ref() {
+            plugin_runtime = engine.plugin_runtime_status();
+        }
         if let Some(runtime) = self.capture_runtime.lock().as_ref() {
             capture_runtime = runtime.status();
         }
         capture_runtime =
             enrich_capture_runtime_with_external_inputs(capture_runtime, &external_input_snapshots);
+        self.state.lock().plugin_runtime = plugin_runtime.clone();
 
         DaemonStatus {
             running,
@@ -1048,6 +1057,7 @@ impl MarsDaemon {
             external_runtime,
             capture_runtime,
             sink_runtime,
+            plugin_runtime,
             updated_at: Utc::now(),
         }
     }
@@ -1225,6 +1235,11 @@ impl MarsDaemon {
             .filter(|sink| sink.health == SinkRuntimeHealth::Failed)
             .count();
         let sink_write_errors = state.sink_runtime.write_errors;
+        let plugin_active = state.plugin_runtime.active_instances;
+        let plugin_failed = state.plugin_runtime.failed_instances;
+        let plugin_timeouts = state.plugin_runtime.timeout_count;
+        let plugin_errors = state.plugin_runtime.error_count;
+        let plugin_restarts = state.plugin_runtime.restart_count;
         if capture_failed_taps > 0 {
             for error in &state.capture_runtime.errors {
                 notes.push(format!("capture runtime error: {error}"));
@@ -1234,6 +1249,12 @@ impl MarsDaemon {
             notes.push(format!(
                 "sink runtime health: active={} degraded={} failed={} write_errors={}",
                 sink_active, sink_degraded, sink_failed, sink_write_errors
+            ));
+        }
+        if plugin_failed > 0 || plugin_timeouts > 0 || plugin_errors > 0 || plugin_restarts > 0 {
+            notes.push(format!(
+                "plugin runtime health: active={} failed={} timeouts={} errors={} restarts={}",
+                plugin_active, plugin_failed, plugin_timeouts, plugin_errors, plugin_restarts
             ));
         }
         notes.extend(feedback_risk_notes(state.graph.as_ref(), &state.devices));
@@ -1255,6 +1276,11 @@ impl MarsDaemon {
             sink_degraded,
             sink_failed,
             sink_write_errors,
+            plugin_active,
+            plugin_failed,
+            plugin_timeouts,
+            plugin_errors,
+            plugin_restarts,
             notes,
         }
     }

--- a/crates/mars-daemon/src/tests.rs
+++ b/crates/mars-daemon/src/tests.rs
@@ -11,11 +11,12 @@ use mars_graph::build_routing_graph;
 use mars_ipc::{DaemonRequest, DaemonResponse, IpcClient, LogRequest};
 use mars_shm::{RingSpec, StreamDirection, global_registry, stream_name};
 use mars_types::{
-    AutoOrU32, CaptureRuntimeHealth, CaptureRuntimeKind, CaptureRuntimeStatus,
+    AuPluginApi, AutoOrU32, CaptureRuntimeHealth, CaptureRuntimeKind, CaptureRuntimeStatus,
     CaptureRuntimeTapStatus, DeviceDescriptor, FileSink, FileSinkFormat, NodeKind, Pipe,
-    ProcessTap, ProcessTapSelector, ProcessorChain, ProcessorDefinition, ProcessorKind, Profile,
-    Route, RouteMatrix, SinkRuntimeHealth, SinkRuntimeKind, SinkRuntimeSinkStatus,
-    SinkRuntimeStatus, SystemTap, SystemTapMode, VirtualInputDevice, VirtualOutputDevice,
+    PluginHostHealth, PluginHostInstanceStatus, PluginHostRuntimeStatus, ProcessTap,
+    ProcessTapSelector, ProcessorChain, ProcessorDefinition, ProcessorKind, Profile, Route,
+    RouteMatrix, SinkRuntimeHealth, SinkRuntimeKind, SinkRuntimeSinkStatus, SinkRuntimeStatus,
+    SystemTap, SystemTapMode, VirtualInputDevice, VirtualOutputDevice,
 };
 
 use super::{
@@ -383,6 +384,60 @@ fn doctor_report_includes_sink_runtime_health_summary() {
             .notes
             .iter()
             .any(|note| note.contains("sink runtime health"))
+    );
+}
+
+#[test]
+fn doctor_report_includes_plugin_runtime_health_summary() {
+    let daemon = MarsDaemon::new(temp_log_path("doctor-plugin-health"));
+    {
+        let mut state = daemon.state.lock();
+        state.plugin_runtime = PluginHostRuntimeStatus {
+            active_instances: 1,
+            failed_instances: 1,
+            timeout_count: 2,
+            error_count: 3,
+            restart_count: 4,
+            instances: vec![
+                PluginHostInstanceStatus {
+                    id: "au-main".to_string(),
+                    api: AuPluginApi::Auv2,
+                    health: PluginHostHealth::Healthy,
+                    loaded: true,
+                    host_pid: Some(101),
+                    process_calls: 50,
+                    timeout_count: 0,
+                    error_count: 0,
+                    restart_count: 0,
+                    last_error: None,
+                },
+                PluginHostInstanceStatus {
+                    id: "au-failed".to_string(),
+                    api: AuPluginApi::Auv3,
+                    health: PluginHostHealth::Failed,
+                    loaded: false,
+                    host_pid: None,
+                    process_calls: 12,
+                    timeout_count: 2,
+                    error_count: 3,
+                    restart_count: 4,
+                    last_error: Some("plugin host crashed".to_string()),
+                },
+            ],
+        };
+    }
+
+    let report = daemon.doctor_report_internal();
+    assert_eq!(report.plugin_active, 1);
+    assert_eq!(report.plugin_failed, 1);
+    assert_eq!(report.plugin_timeouts, 2);
+    assert_eq!(report.plugin_errors, 3);
+    assert_eq!(report.plugin_restarts, 4);
+    assert!(
+        report
+            .notes
+            .iter()
+            .any(|note| note.contains("plugin runtime health"))
     );
 }
 

--- a/crates/mars-engine/Cargo.toml
+++ b/crates/mars-engine/Cargo.toml
@@ -26,3 +26,7 @@ stats_alloc = "0.1.10"
 [[bench]]
 name = "engine"
 harness = false
+
+[[bench]]
+name = "plugin_host"
+harness = false

--- a/crates/mars-engine/benches/plugin_host.rs
+++ b/crates/mars-engine/benches/plugin_host.rs
@@ -1,0 +1,214 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use mars_engine::{Engine, EngineSnapshot};
+use mars_graph::build_routing_graph;
+use mars_types::{
+    ProcessorChain, ProcessorDefinition, ProcessorKind, Profile, Route, RouteMatrix,
+    VirtualInputDevice, VirtualOutputDevice,
+};
+use serde_json::json;
+
+fn unique_temp_path(tag: &str, ext: &str) -> PathBuf {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "mars-au-bench-{tag}-{ts}-{}.{}",
+        std::process::id(),
+        ext
+    ))
+}
+
+fn write_mock_plugin_host_script() -> PathBuf {
+    let script_path = unique_temp_path("mock-plugin-host", "py");
+    let script = r#"#!/usr/bin/env python3
+import json
+import os
+import socket
+import sys
+
+def send(conn, obj):
+    conn.sendall((json.dumps(obj) + "\n").encode("utf-8"))
+
+def parse_socket(argv):
+    for i, arg in enumerate(argv):
+        if arg == "--socket" and i + 1 < len(argv):
+            return argv[i + 1]
+    raise RuntimeError("missing --socket")
+
+def main():
+    socket_path = parse_socket(sys.argv[1:])
+    if os.path.exists(socket_path):
+        os.remove(socket_path)
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(socket_path)
+    listener.listen(1)
+    conn, _ = listener.accept()
+    instances = {}
+    buffer = b""
+    while True:
+        chunk = conn.recv(4096)
+        if not chunk:
+            break
+        buffer += chunk
+        while b"\n" in buffer:
+            line, buffer = buffer.split(b"\n", 1)
+            if not line:
+                continue
+            request = json.loads(line.decode("utf-8"))
+            kind = request["kind"]
+            if kind == "handshake":
+                send(conn, {"kind": "handshake", "protocol_version": 1})
+            elif kind == "load":
+                instances[request["instance_id"]] = {"prepared": False}
+                send(conn, {"kind": "ack"})
+            elif kind == "prepare":
+                send(conn, {"kind": "ack"})
+            elif kind == "process":
+                send(conn, {"kind": "processed", "samples": request["samples"]})
+            elif kind == "reset":
+                send(conn, {"kind": "ack"})
+            elif kind == "unload":
+                instances.pop(request["instance_id"], None)
+                send(conn, {"kind": "ack"})
+            elif kind == "shutdown":
+                send(conn, {"kind": "ack"})
+                conn.close()
+                listener.close()
+                if os.path.exists(socket_path):
+                    os.remove(socket_path)
+                return
+            else:
+                send(conn, {"kind": "error", "message": "unknown request"})
+
+if __name__ == "__main__":
+    main()
+"#;
+    fs::write(&script_path, script).expect("write mock plugin host script");
+    script_path
+}
+
+fn build_au_engine(script_path: &PathBuf, frames: u32) -> Engine {
+    let mut profile = Profile::default();
+    profile.virtual_devices.outputs.push(VirtualOutputDevice {
+        id: "src".to_string(),
+        name: "Src".to_string(),
+        channels: Some(2),
+        uid: None,
+        hidden: false,
+    });
+    profile.virtual_devices.inputs.push(VirtualInputDevice {
+        id: "sink".to_string(),
+        name: "Sink".to_string(),
+        channels: Some(2),
+        uid: None,
+        mix: None,
+    });
+    profile.processors.push(ProcessorDefinition {
+        id: "au-main".to_string(),
+        kind: ProcessorKind::Au,
+        config: json!({
+            "api": "auv2",
+            "component_type": "aufx",
+            "component_subtype": "gain",
+            "component_manufacturer": "appl",
+            "process_timeout_ms": 25,
+            "max_frames": 2048,
+            "host_command": "python3",
+            "host_args": [script_path.to_string_lossy().to_string()],
+        }),
+    });
+    profile.processor_chains.push(ProcessorChain {
+        id: "chain-au".to_string(),
+        processors: vec!["au-main".to_string()],
+    });
+    profile.routes.push(Route {
+        id: "route-au".to_string(),
+        from: "src".to_string(),
+        to: "sink".to_string(),
+        enabled: true,
+        matrix: RouteMatrix {
+            rows: 2,
+            cols: 2,
+            coefficients: vec![vec![1.0, 0.0], vec![0.0, 1.0]],
+        },
+        chain: Some("chain-au".to_string()),
+        gain_db: 0.0,
+        mute: false,
+        pan: 0.0,
+        delay_ms: 0.0,
+    });
+
+    let graph = build_routing_graph(&profile).expect("graph");
+    Engine::new(EngineSnapshot {
+        graph,
+        sample_rate: 48_000,
+        buffer_frames: frames,
+    })
+}
+
+fn bench_plugin_host(c: &mut Criterion) {
+    let script_path = write_mock_plugin_host_script();
+    let frames = 256usize;
+    let engine = build_au_engine(&script_path, frames as u32);
+
+    let mut sources = HashMap::new();
+    let input = (0..(frames * 2))
+        .map(|index| ((index as f32) * 0.01).sin())
+        .collect::<Vec<_>>();
+    sources.insert("src".to_string(), input);
+
+    for _ in 0..16 {
+        engine.render_cycle(frames, &sources).expect("warm render");
+        thread::sleep(Duration::from_millis(2));
+    }
+
+    let mut overhead = c.benchmark_group("engine/au/ipc_overhead");
+    overhead.bench_function(BenchmarkId::new("render_submit", frames), |b| {
+        b.iter(|| {
+            engine.render_cycle(frames, &sources).expect("render");
+        })
+    });
+    overhead.finish();
+
+    let mut latency = c.benchmark_group("engine/au/plugin_latency");
+    latency.bench_function(BenchmarkId::new("process_roundtrip", frames), |b| {
+        let mut expected_calls = engine
+            .plugin_runtime_status()
+            .instances
+            .first()
+            .map_or(0, |status| status.process_calls);
+        b.iter_custom(|iterations| {
+            let started = Instant::now();
+            for _ in 0..iterations {
+                expected_calls = expected_calls.saturating_add(1);
+                engine.render_cycle(frames, &sources).expect("render");
+                let deadline = Instant::now() + Duration::from_millis(100);
+                loop {
+                    let calls = engine
+                        .plugin_runtime_status()
+                        .instances
+                        .first()
+                        .map_or(0, |status| status.process_calls);
+                    if calls >= expected_calls || Instant::now() >= deadline {
+                        break;
+                    }
+                    thread::sleep(Duration::from_millis(1));
+                }
+            }
+            started.elapsed()
+        })
+    });
+    latency.finish();
+
+    let _ = fs::remove_file(script_path);
+}
+
+criterion_group!(benches, bench_plugin_host);
+criterion_main!(benches);

--- a/crates/mars-engine/src/au_host.rs
+++ b/crates/mars-engine/src/au_host.rs
@@ -1,0 +1,599 @@
+#![forbid(unsafe_code)]
+
+use std::collections::hash_map::DefaultHasher;
+use std::env;
+use std::hash::{Hash, Hasher};
+use std::io::{BufRead, BufReader, ErrorKind, Write};
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
+use std::sync::mpsc::{
+    Receiver, RecvTimeoutError, SyncSender, TryRecvError, TrySendError, channel, sync_channel,
+};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use mars_types::{
+    AuPluginConfig, PLUGIN_HOST_PROTOCOL_VERSION, PluginHostHealth, PluginHostInstanceStatus,
+    PluginHostRequest, PluginHostResponse,
+};
+use parking_lot::Mutex;
+
+const RT_QUEUE_CAPACITY: usize = 2;
+const RESULT_QUEUE_CAPACITY: usize = 1;
+const WORKER_POLL_INTERVAL_MS: u64 = 5;
+const HOST_STARTUP_TIMEOUT_MS: u64 = 2_000;
+const HOST_CONNECT_RETRY_MS: u64 = 20;
+
+#[derive(Debug)]
+pub struct AuWorker {
+    request_tx: SyncSender<AuProcessRequest>,
+    result_rx: Receiver<Vec<f32>>,
+    stop_tx: std::sync::mpsc::Sender<()>,
+    status: Arc<Mutex<PluginHostInstanceStatus>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AuWorkerSettings {
+    pub processor_id: String,
+    pub config: AuPluginConfig,
+    pub sample_rate: u32,
+    pub channels: usize,
+    pub max_frames: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct AuProcessRequest {
+    pub frames: usize,
+    pub channels: usize,
+    pub samples: Vec<f32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuSubmitError {
+    Full,
+    Disconnected,
+}
+
+#[derive(Debug)]
+struct HostSession {
+    child: Child,
+    socket_path: PathBuf,
+    writer: UnixStream,
+    reader: BufReader<UnixStream>,
+    instance_id: String,
+    config: AuPluginConfig,
+}
+
+#[derive(Debug, Clone)]
+enum HostSessionError {
+    Timeout(String),
+    Io(String),
+}
+
+impl HostSessionError {
+    fn is_timeout(&self) -> bool {
+        matches!(self, Self::Timeout(_))
+    }
+
+    fn message(&self) -> String {
+        match self {
+            Self::Timeout(message) | Self::Io(message) => message.clone(),
+        }
+    }
+}
+
+impl AuWorker {
+    pub fn start(settings: AuWorkerSettings) -> Self {
+        let (request_tx, request_rx) = sync_channel::<AuProcessRequest>(RT_QUEUE_CAPACITY);
+        let (result_tx, result_rx) = sync_channel::<Vec<f32>>(RESULT_QUEUE_CAPACITY);
+        let (stop_tx, stop_rx) = channel::<()>();
+        let status = Arc::new(Mutex::new(PluginHostInstanceStatus {
+            id: settings.processor_id.clone(),
+            api: settings.config.api,
+            health: PluginHostHealth::Degraded,
+            loaded: false,
+            host_pid: None,
+            process_calls: 0,
+            timeout_count: 0,
+            error_count: 0,
+            restart_count: 0,
+            last_error: None,
+        }));
+
+        let thread_status = status.clone();
+        let handle = thread::Builder::new()
+            .name(format!("marsd-au-{}", settings.processor_id))
+            .spawn(move || {
+                run_worker(settings, request_rx, result_tx, stop_rx, thread_status);
+            })
+            .ok();
+
+        Self {
+            request_tx,
+            result_rx,
+            stop_tx,
+            status,
+            handle,
+        }
+    }
+
+    pub fn try_submit(&self, request: AuProcessRequest) -> Result<(), AuSubmitError> {
+        match self.request_tx.try_send(request) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_request)) => {
+                let mut status = self.status.lock();
+                status.timeout_count = status.timeout_count.saturating_add(1);
+                status.health = PluginHostHealth::Degraded;
+                status.last_error = Some("plugin host rt queue full".to_string());
+                Err(AuSubmitError::Full)
+            }
+            Err(TrySendError::Disconnected(_request)) => {
+                let mut status = self.status.lock();
+                status.error_count = status.error_count.saturating_add(1);
+                status.health = PluginHostHealth::Failed;
+                status.loaded = false;
+                status.host_pid = None;
+                status.last_error = Some("plugin host worker disconnected".to_string());
+                Err(AuSubmitError::Disconnected)
+            }
+        }
+    }
+
+    pub fn drain_latest_result(&self) -> Option<Vec<f32>> {
+        let mut latest = None;
+        loop {
+            match self.result_rx.try_recv() {
+                Ok(result) => latest = Some(result),
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => break,
+            }
+        }
+        latest
+    }
+
+    pub fn status_snapshot(&self) -> PluginHostInstanceStatus {
+        self.status.lock().clone()
+    }
+
+    pub fn stop(&mut self) {
+        let _ = self.stop_tx.send(());
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for AuWorker {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn run_worker(
+    settings: AuWorkerSettings,
+    request_rx: Receiver<AuProcessRequest>,
+    result_tx: SyncSender<Vec<f32>>,
+    stop_rx: std::sync::mpsc::Receiver<()>,
+    status: Arc<Mutex<PluginHostInstanceStatus>>,
+) {
+    let mut session = match HostSession::start(&settings) {
+        Ok(session) => {
+            {
+                let mut lock = status.lock();
+                lock.loaded = true;
+                lock.health = PluginHostHealth::Healthy;
+                lock.host_pid = Some(session.pid());
+                lock.last_error = None;
+            }
+            Some(session)
+        }
+        Err(error) => {
+            let mut lock = status.lock();
+            lock.loaded = false;
+            lock.host_pid = None;
+            lock.health = PluginHostHealth::Failed;
+            lock.error_count = lock.error_count.saturating_add(1);
+            lock.last_error = Some(error.message());
+            None
+        }
+    };
+
+    let poll = Duration::from_millis(WORKER_POLL_INTERVAL_MS);
+    loop {
+        if stop_rx.try_recv().is_ok() {
+            break;
+        }
+
+        let request = match request_rx.recv_timeout(poll) {
+            Ok(request) => request,
+            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Disconnected) => break,
+        };
+
+        {
+            let mut lock = status.lock();
+            lock.process_calls = lock.process_calls.saturating_add(1);
+        }
+
+        if session.is_none() {
+            match HostSession::start(&settings) {
+                Ok(new_session) => {
+                    let mut lock = status.lock();
+                    lock.loaded = true;
+                    lock.host_pid = Some(new_session.pid());
+                    lock.health = PluginHostHealth::Healthy;
+                    lock.last_error = None;
+                    session = Some(new_session);
+                }
+                Err(error) => {
+                    let mut lock = status.lock();
+                    lock.error_count = lock.error_count.saturating_add(1);
+                    lock.health = PluginHostHealth::Failed;
+                    lock.loaded = false;
+                    lock.host_pid = None;
+                    lock.last_error = Some(error.message());
+                    let _ = result_tx.try_send(request.samples);
+                    continue;
+                }
+            }
+        }
+
+        let mut failed = None;
+        if let Some(current) = session.as_mut() {
+            match current.process(request.frames, request.channels, request.samples.clone()) {
+                Ok(samples) => {
+                    let mut lock = status.lock();
+                    lock.loaded = true;
+                    lock.health = PluginHostHealth::Healthy;
+                    lock.host_pid = Some(current.pid());
+                    lock.last_error = None;
+                    let _ = result_tx.try_send(samples);
+                }
+                Err(error) => {
+                    failed = Some(error);
+                }
+            }
+        }
+
+        if let Some(error) = failed {
+            let mut lock = status.lock();
+            lock.error_count = lock.error_count.saturating_add(1);
+            if error.is_timeout() {
+                lock.timeout_count = lock.timeout_count.saturating_add(1);
+                lock.health = PluginHostHealth::Degraded;
+            } else {
+                lock.health = PluginHostHealth::Failed;
+            }
+            lock.loaded = false;
+            lock.host_pid = None;
+            lock.last_error = Some(error.message());
+            lock.restart_count = lock.restart_count.saturating_add(1);
+            drop(lock);
+
+            if let Some(mut current) = session.take() {
+                current.terminate();
+            }
+            let _ = result_tx.try_send(request.samples);
+        }
+    }
+
+    if let Some(mut current) = session {
+        current.shutdown();
+    }
+}
+
+impl HostSession {
+    fn start(settings: &AuWorkerSettings) -> Result<Self, HostSessionError> {
+        let socket_path = make_socket_path(&settings.processor_id);
+        let mut command = plugin_host_command(&settings.config);
+        command
+            .arg("--socket")
+            .arg(&socket_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+
+        let mut child = command.spawn().map_err(|error| {
+            HostSessionError::Io(format!("failed to spawn plugin host: {error}"))
+        })?;
+
+        let started = Instant::now();
+        let startup_timeout = Duration::from_millis(HOST_STARTUP_TIMEOUT_MS);
+        let stream = loop {
+            match UnixStream::connect(&socket_path) {
+                Ok(stream) => break stream,
+                Err(error) => {
+                    if started.elapsed() >= startup_timeout {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        let _ = std::fs::remove_file(&socket_path);
+                        return Err(HostSessionError::Timeout(format!(
+                            "plugin host did not accept connection in {}ms: {error}",
+                            HOST_STARTUP_TIMEOUT_MS
+                        )));
+                    }
+                    thread::sleep(Duration::from_millis(HOST_CONNECT_RETRY_MS));
+                }
+            }
+        };
+
+        stream
+            .set_read_timeout(Some(Duration::from_millis(
+                settings.config.process_timeout_ms as u64,
+            )))
+            .map_err(|error| {
+                HostSessionError::Io(format!("failed to set plugin host read timeout: {error}"))
+            })?;
+        stream
+            .set_write_timeout(Some(Duration::from_millis(
+                settings.config.process_timeout_ms as u64,
+            )))
+            .map_err(|error| {
+                HostSessionError::Io(format!("failed to set plugin host write timeout: {error}"))
+            })?;
+
+        let reader_stream = stream.try_clone().map_err(|error| {
+            HostSessionError::Io(format!("failed to clone plugin host stream: {error}"))
+        })?;
+
+        let mut session = Self {
+            child,
+            socket_path,
+            writer: stream,
+            reader: BufReader::new(reader_stream),
+            instance_id: settings.processor_id.clone(),
+            config: settings.config.clone(),
+        };
+
+        session.handshake()?;
+        session.load()?;
+        session.prepare(settings.sample_rate, settings.channels, settings.max_frames)?;
+        Ok(session)
+    }
+
+    fn pid(&self) -> u32 {
+        self.child.id()
+    }
+
+    fn handshake(&mut self) -> Result<(), HostSessionError> {
+        let response = self.exchange(
+            PluginHostRequest::Handshake {
+                protocol_version: PLUGIN_HOST_PROTOCOL_VERSION,
+            },
+            Duration::from_millis(250),
+        )?;
+        match response {
+            PluginHostResponse::Handshake { protocol_version }
+                if protocol_version == PLUGIN_HOST_PROTOCOL_VERSION =>
+            {
+                Ok(())
+            }
+            PluginHostResponse::Handshake { protocol_version } => {
+                Err(HostSessionError::Io(format!(
+                    "plugin host protocol mismatch: expected {PLUGIN_HOST_PROTOCOL_VERSION}, got {protocol_version}"
+                )))
+            }
+            PluginHostResponse::Error { message } => Err(HostSessionError::Io(message)),
+            other => Err(HostSessionError::Io(format!(
+                "unexpected handshake response: {other:?}"
+            ))),
+        }
+    }
+
+    fn load(&mut self) -> Result<(), HostSessionError> {
+        let response = self.exchange(
+            PluginHostRequest::Load {
+                instance_id: self.instance_id.clone(),
+                config: self.config.clone(),
+            },
+            Duration::from_millis(500),
+        )?;
+        expect_ack(response, "load")
+    }
+
+    fn prepare(
+        &mut self,
+        sample_rate: u32,
+        channels: usize,
+        max_frames: usize,
+    ) -> Result<(), HostSessionError> {
+        let response = self.exchange(
+            PluginHostRequest::Prepare {
+                instance_id: self.instance_id.clone(),
+                sample_rate,
+                channels: channels as u16,
+                max_frames: max_frames as u32,
+            },
+            Duration::from_millis(500),
+        )?;
+        expect_ack(response, "prepare")
+    }
+
+    fn process(
+        &mut self,
+        frames: usize,
+        channels: usize,
+        samples: Vec<f32>,
+    ) -> Result<Vec<f32>, HostSessionError> {
+        let timeout = Duration::from_millis(self.config.process_timeout_ms as u64);
+        let response = self.exchange(
+            PluginHostRequest::Process {
+                instance_id: self.instance_id.clone(),
+                channels: channels as u16,
+                frames: frames as u32,
+                samples,
+            },
+            timeout,
+        )?;
+        match response {
+            PluginHostResponse::Processed { samples } => Ok(samples),
+            PluginHostResponse::Error { message } => Err(HostSessionError::Io(message)),
+            other => Err(HostSessionError::Io(format!(
+                "unexpected process response: {other:?}"
+            ))),
+        }
+    }
+
+    fn reset(&mut self) {
+        let _ = self.exchange(
+            PluginHostRequest::Reset {
+                instance_id: self.instance_id.clone(),
+            },
+            Duration::from_millis(250),
+        );
+    }
+
+    fn unload(&mut self) {
+        let _ = self.exchange(
+            PluginHostRequest::Unload {
+                instance_id: self.instance_id.clone(),
+            },
+            Duration::from_millis(250),
+        );
+    }
+
+    fn shutdown(&mut self) {
+        self.reset();
+        self.unload();
+        let _ = self.exchange(PluginHostRequest::Shutdown, Duration::from_millis(250));
+        self.terminate();
+    }
+
+    fn terminate(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+
+    fn exchange(
+        &mut self,
+        request: PluginHostRequest,
+        timeout: Duration,
+    ) -> Result<PluginHostResponse, HostSessionError> {
+        self.writer
+            .set_write_timeout(Some(timeout))
+            .map_err(|error| {
+                HostSessionError::Io(format!("failed to set write timeout: {error}"))
+            })?;
+        self.reader
+            .get_mut()
+            .set_read_timeout(Some(timeout))
+            .map_err(|error| {
+                HostSessionError::Io(format!("failed to set read timeout: {error}"))
+            })?;
+
+        let mut payload = serde_json::to_string(&request).map_err(|error| {
+            HostSessionError::Io(format!("failed to serialize request: {error}"))
+        })?;
+        payload.push('\n');
+        self.writer
+            .write_all(payload.as_bytes())
+            .map_err(map_io_timeout)?;
+        self.writer.flush().map_err(map_io_timeout)?;
+
+        let mut line = String::new();
+        let bytes = self.reader.read_line(&mut line).map_err(map_io_timeout)?;
+        if bytes == 0 {
+            return Err(HostSessionError::Io(
+                "plugin host closed connection unexpectedly".to_string(),
+            ));
+        }
+        serde_json::from_str::<PluginHostResponse>(&line)
+            .map_err(|error| HostSessionError::Io(format!("failed to decode response: {error}")))
+    }
+}
+
+fn expect_ack(response: PluginHostResponse, operation: &str) -> Result<(), HostSessionError> {
+    match response {
+        PluginHostResponse::Ack => Ok(()),
+        PluginHostResponse::Error { message } => Err(HostSessionError::Io(format!(
+            "plugin host {operation} failed: {message}"
+        ))),
+        other => Err(HostSessionError::Io(format!(
+            "unexpected {operation} response: {other:?}"
+        ))),
+    }
+}
+
+fn map_io_timeout(error: std::io::Error) -> HostSessionError {
+    match error.kind() {
+        ErrorKind::WouldBlock | ErrorKind::TimedOut => {
+            HostSessionError::Timeout(format!("plugin host request timed out: {error}"))
+        }
+        _ => HostSessionError::Io(format!("plugin host io error: {error}")),
+    }
+}
+
+fn plugin_host_command(config: &AuPluginConfig) -> Command {
+    if !config.host_command.trim().is_empty() {
+        let mut command = Command::new(config.host_command.trim());
+        for arg in &config.host_args {
+            command.arg(arg);
+        }
+        return command;
+    }
+
+    let binary =
+        env::var("MARS_PLUGIN_HOST_BIN").unwrap_or_else(|_| "mars-plugin-host".to_string());
+    let mut command = Command::new(binary);
+    if let Ok(args) = env::var("MARS_PLUGIN_HOST_ARGS") {
+        for arg in args.split_whitespace() {
+            if !arg.is_empty() {
+                command.arg(arg);
+            }
+        }
+    }
+    command
+}
+
+fn make_socket_path(processor_id: &str) -> PathBuf {
+    const UNIX_SOCKET_PATH_LIMIT: usize = 103;
+
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    let mut safe_id = processor_id
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if safe_id.len() > 16 {
+        safe_id.truncate(16);
+    }
+
+    let mut path = PathBuf::from("/tmp");
+    path.push(format!("marsph-{pid}-{safe_id}-{ts:x}.sock"));
+    if path.to_string_lossy().len() <= UNIX_SOCKET_PATH_LIMIT {
+        return path;
+    }
+
+    let mut hasher = DefaultHasher::new();
+    processor_id.hash(&mut hasher);
+    let digest = hasher.finish();
+    let mut fallback = PathBuf::from("/tmp");
+    fallback.push(format!("mph-{pid}-{digest:x}-{ts:x}.sock"));
+    fallback
+}
+
+#[cfg(test)]
+mod tests {
+    use super::make_socket_path;
+
+    #[test]
+    fn socket_path_respects_unix_length_limit() {
+        let path = make_socket_path(
+            "processor-with-long-id-and-extra-segments-that-would-overflow-standard-unix-path",
+        );
+        assert!(path.to_string_lossy().len() <= 103);
+    }
+}

--- a/crates/mars-engine/src/lib.rs
+++ b/crates/mars-engine/src/lib.rs
@@ -1,14 +1,20 @@
 #![forbid(unsafe_code)]
 //! Realtime-safe-ish audio graph rendering engine.
 
+mod au_host;
+
 use std::collections::{BTreeMap, HashMap};
 use std::f32::consts::{FRAC_PI_4, PI};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use arc_swap::ArcSwap;
+use au_host::{AuProcessRequest, AuSubmitError, AuWorker, AuWorkerSettings};
 use mars_graph::RoutingGraph;
-use mars_types::{MixMode, ProcessorKind, ProcessorRuntimeStats, RuntimeCounters};
+use mars_types::{
+    AuPluginConfig, MixMode, PluginHostHealth, PluginHostInstanceStatus, PluginHostRuntimeStatus,
+    ProcessorKind, ProcessorRuntimeStats, RuntimeCounters,
+};
 use parking_lot::Mutex;
 use serde::Deserialize;
 use serde_json::Value;
@@ -100,6 +106,9 @@ trait ProcessorBlock: Send + Sync + std::fmt::Debug {
     );
     fn reset(&self);
     fn stats(&self) -> ProcessorRuntimeStats;
+    fn plugin_status(&self) -> Option<PluginHostInstanceStatus> {
+        None
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -115,14 +124,6 @@ struct ProcessorCounters {
     process_calls: AtomicU64,
     reset_calls: AtomicU64,
     last_generation: AtomicU64,
-}
-
-#[derive(Debug)]
-struct PassthroughProcessorBlock {
-    id: String,
-    _kind: ProcessorKind,
-    prepared: AtomicBool,
-    counters: ProcessorCounters,
 }
 
 #[derive(Debug)]
@@ -159,6 +160,23 @@ struct TimeShiftProcessorBlock {
     state: Mutex<TimeShiftProcessorState>,
     prepared: AtomicBool,
     counters: ProcessorCounters,
+}
+
+#[derive(Debug)]
+struct AuProcessorBlock {
+    id: String,
+    config: AuPluginConfig,
+    state: Mutex<AuProcessorState>,
+    prepared: AtomicBool,
+    counters: ProcessorCounters,
+}
+
+#[derive(Debug, Default)]
+struct AuProcessorState {
+    worker: Option<AuWorker>,
+    channels: usize,
+    sample_rate_hz: u32,
+    max_frames: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -493,6 +511,16 @@ impl TimeShiftConfig {
     }
 }
 
+fn au_config_from_json(config_json: &str) -> AuPluginConfig {
+    let value =
+        serde_json::from_str::<Value>(config_json).expect("compiled config must be valid JSON");
+    if value.is_null() {
+        return AuPluginConfig::default();
+    }
+    serde_json::from_value::<AuPluginConfig>(value)
+        .expect("compiled au config must match validated shape")
+}
+
 fn peaking_coefficients(
     sample_rate_hz: u32,
     freq_hz: f32,
@@ -575,9 +603,9 @@ impl ProcessorSchedule {
                         compiled.id.clone(),
                         TimeShiftConfig::from_config_json(&compiled.config_json),
                     )),
-                    _ => Arc::new(PassthroughProcessorBlock::new(
+                    ProcessorKind::Au => Arc::new(AuProcessorBlock::new(
                         compiled.id.clone(),
-                        compiled.kind,
+                        au_config_from_json(&compiled.config_json),
                     )),
                 };
                 processor.prepare(context);
@@ -618,6 +646,28 @@ impl ProcessorSchedule {
         }
         merged
     }
+
+    fn plugin_runtime_status(&self) -> PluginHostRuntimeStatus {
+        let mut runtime = PluginHostRuntimeStatus::default();
+        for chain in self.route_chains.values() {
+            for processor in &chain.processors {
+                let Some(status) = processor.plugin_status() else {
+                    continue;
+                };
+                runtime.timeout_count = runtime.timeout_count.saturating_add(status.timeout_count);
+                runtime.error_count = runtime.error_count.saturating_add(status.error_count);
+                runtime.restart_count = runtime.restart_count.saturating_add(status.restart_count);
+                if status.loaded && status.health != PluginHostHealth::Failed {
+                    runtime.active_instances = runtime.active_instances.saturating_add(1);
+                }
+                if status.health == PluginHostHealth::Failed {
+                    runtime.failed_instances = runtime.failed_instances.saturating_add(1);
+                }
+                runtime.instances.push(status);
+            }
+        }
+        runtime
+    }
 }
 
 impl Drop for ProcessorSchedule {
@@ -646,63 +696,6 @@ impl ProcessorRouteChain {
     fn reset(&self) {
         for processor in &self.processors {
             processor.reset();
-        }
-    }
-}
-
-impl PassthroughProcessorBlock {
-    fn new(id: String, kind: ProcessorKind) -> Self {
-        Self {
-            id,
-            _kind: kind,
-            prepared: AtomicBool::new(false),
-            counters: ProcessorCounters::default(),
-        }
-    }
-}
-
-impl ProcessorBlock for PassthroughProcessorBlock {
-    fn id(&self) -> &str {
-        &self.id
-    }
-
-    fn prepare(&self, context: ProcessorPrepareContext) {
-        let _ = (context.channels, context.sample_rate, context.max_frames);
-        self.prepared.store(true, Ordering::Relaxed);
-        self.counters.prepare_calls.fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn process(
-        &self,
-        _samples: &mut [f32],
-        _channels: usize,
-        _frames: usize,
-        control: Option<&ProcessorControl>,
-        bypass: bool,
-    ) {
-        if bypass || !self.prepared.load(Ordering::Relaxed) {
-            return;
-        }
-        if let Some(control) = control {
-            self.counters
-                .last_generation
-                .store(control.generation, Ordering::Relaxed);
-        }
-        self.counters.process_calls.fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn reset(&self) {
-        if self.prepared.swap(false, Ordering::Relaxed) {
-            self.counters.reset_calls.fetch_add(1, Ordering::Relaxed);
-        }
-    }
-
-    fn stats(&self) -> ProcessorRuntimeStats {
-        ProcessorRuntimeStats {
-            prepare_calls: self.counters.prepare_calls.load(Ordering::Relaxed),
-            process_calls: self.counters.process_calls.load(Ordering::Relaxed),
-            reset_calls: self.counters.reset_calls.load(Ordering::Relaxed),
-            last_generation: self.counters.last_generation.load(Ordering::Relaxed),
         }
     }
 }
@@ -1132,6 +1125,134 @@ impl ProcessorBlock for TimeShiftProcessorBlock {
     }
 }
 
+impl AuProcessorBlock {
+    fn new(id: String, config: AuPluginConfig) -> Self {
+        Self {
+            id,
+            config,
+            state: Mutex::new(AuProcessorState::default()),
+            prepared: AtomicBool::new(false),
+            counters: ProcessorCounters::default(),
+        }
+    }
+}
+
+impl ProcessorBlock for AuProcessorBlock {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn prepare(&self, context: ProcessorPrepareContext) {
+        let mut state = self.state.lock();
+        if let Some(worker) = state.worker.as_mut() {
+            worker.stop();
+        }
+        state.channels = context.channels.max(1);
+        state.sample_rate_hz = context.sample_rate.max(1);
+        state.max_frames = context.max_frames.max(1);
+        state.worker = Some(AuWorker::start(AuWorkerSettings {
+            processor_id: self.id.clone(),
+            config: self.config.clone(),
+            sample_rate: state.sample_rate_hz,
+            channels: state.channels,
+            max_frames: state.max_frames,
+        }));
+        self.prepared.store(true, Ordering::Relaxed);
+        self.counters.prepare_calls.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn process(
+        &self,
+        samples: &mut [f32],
+        channels: usize,
+        frames: usize,
+        control: Option<&ProcessorControl>,
+        bypass: bool,
+    ) {
+        if !self.prepared.load(Ordering::Relaxed) || channels == 0 || frames == 0 {
+            return;
+        }
+        if let Some(control) = control {
+            self.counters
+                .last_generation
+                .store(control.generation, Ordering::Relaxed);
+        }
+
+        if bypass {
+            self.counters.process_calls.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+
+        let state = self.state.lock();
+        if let Some(worker) = state.worker.as_ref() {
+            let request_samples = samples.to_vec();
+            if let Some(processed) = worker.drain_latest_result() {
+                if processed.len() == samples.len() {
+                    samples.copy_from_slice(&processed);
+                }
+            }
+            let request = AuProcessRequest {
+                frames,
+                channels,
+                samples: request_samples,
+            };
+            let _ = match worker.try_submit(request) {
+                Ok(()) => Ok(()),
+                Err(AuSubmitError::Full) | Err(AuSubmitError::Disconnected) => Err(()),
+            };
+        }
+        self.counters.process_calls.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn reset(&self) {
+        if self.prepared.swap(false, Ordering::Relaxed) {
+            let mut state = self.state.lock();
+            if let Some(worker) = state.worker.as_mut() {
+                worker.stop();
+            }
+            state.worker = None;
+            state.channels = 0;
+            state.sample_rate_hz = 0;
+            state.max_frames = 0;
+            self.counters.reset_calls.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn stats(&self) -> ProcessorRuntimeStats {
+        ProcessorRuntimeStats {
+            prepare_calls: self.counters.prepare_calls.load(Ordering::Relaxed),
+            process_calls: self.counters.process_calls.load(Ordering::Relaxed),
+            reset_calls: self.counters.reset_calls.load(Ordering::Relaxed),
+            last_generation: self.counters.last_generation.load(Ordering::Relaxed),
+        }
+    }
+
+    fn plugin_status(&self) -> Option<PluginHostInstanceStatus> {
+        let state = self.state.lock();
+        let status = if let Some(worker) = state.worker.as_ref() {
+            worker.status_snapshot()
+        } else {
+            PluginHostInstanceStatus {
+                id: self.id.clone(),
+                api: self.config.api,
+                health: if self.prepared.load(Ordering::Relaxed) {
+                    PluginHostHealth::Failed
+                } else {
+                    PluginHostHealth::Degraded
+                },
+                loaded: false,
+                host_pid: None,
+                process_calls: 0,
+                timeout_count: 0,
+                error_count: 0,
+                restart_count: 0,
+                last_error: None,
+            }
+        };
+        Some(status)
+    }
+}
+
 impl Engine {
     #[must_use]
     pub fn new(snapshot: EngineSnapshot) -> Self {
@@ -1176,6 +1297,11 @@ impl Engine {
     #[must_use]
     pub fn processor_runtime_stats(&self) -> BTreeMap<String, ProcessorRuntimeStats> {
         self.processor_schedule.load().stats()
+    }
+
+    #[must_use]
+    pub fn plugin_runtime_status(&self) -> PluginHostRuntimeStatus {
+        self.processor_schedule.load().plugin_runtime_status()
     }
 
     pub fn render_cycle(
@@ -1511,6 +1637,10 @@ fn prepare_node_buffers(
 mod tests {
     use std::collections::{BTreeMap, HashMap};
     use std::f32::consts::{FRAC_1_SQRT_2, PI};
+    use std::fs;
+    use std::path::PathBuf;
+    use std::thread;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use mars_graph::build_routing_graph;
     use mars_types::{
@@ -1751,6 +1881,157 @@ mod tests {
             graph,
             sample_rate,
             buffer_frames,
+        })
+    }
+
+    fn unique_temp_path(tag: &str, ext: &str) -> PathBuf {
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos();
+        std::env::temp_dir().join(format!("mars-au-{tag}-{ts}-{}.{}", std::process::id(), ext))
+    }
+
+    fn write_mock_plugin_host_script(crash_after_process: u64, gain: f32) -> PathBuf {
+        let script_path = unique_temp_path("mock-plugin-host", "py");
+        let script = format!(
+            r#"#!/usr/bin/env python3
+import json
+import os
+import socket
+import sys
+
+CRASH_AFTER = {crash_after_process}
+GAIN = {gain}
+PROCESS_COUNT = 0
+
+def send(conn, obj):
+    conn.sendall((json.dumps(obj) + "\n").encode("utf-8"))
+
+def parse_socket(argv):
+    for i, arg in enumerate(argv):
+        if arg == "--socket" and i + 1 < len(argv):
+            return argv[i + 1]
+    raise RuntimeError("missing --socket")
+
+def main():
+    socket_path = parse_socket(sys.argv[1:])
+    if os.path.exists(socket_path):
+        os.remove(socket_path)
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(socket_path)
+    listener.listen(1)
+    conn, _ = listener.accept()
+    instances = {{}}
+    buffer = b""
+    global PROCESS_COUNT
+    while True:
+        chunk = conn.recv(4096)
+        if not chunk:
+            break
+        buffer += chunk
+        while b"\n" in buffer:
+            line, buffer = buffer.split(b"\n", 1)
+            if not line:
+                continue
+            request = json.loads(line.decode("utf-8"))
+            kind = request["kind"]
+            if kind == "handshake":
+                send(conn, {{"kind": "handshake", "protocol_version": 1}})
+            elif kind == "load":
+                instances[request["instance_id"]] = {{"prepared": False}}
+                send(conn, {{"kind": "ack"}})
+            elif kind == "prepare":
+                instance = instances.get(request["instance_id"])
+                if instance is None:
+                    send(conn, {{"kind": "error", "message": "missing instance"}})
+                else:
+                    instance["prepared"] = True
+                    send(conn, {{"kind": "ack"}})
+            elif kind == "process":
+                PROCESS_COUNT += 1
+                if CRASH_AFTER > 0 and PROCESS_COUNT >= CRASH_AFTER:
+                    os._exit(77)
+                processed = [float(sample) * GAIN for sample in request["samples"]]
+                send(conn, {{"kind": "processed", "samples": processed}})
+            elif kind == "reset":
+                send(conn, {{"kind": "ack"}})
+            elif kind == "unload":
+                instances.pop(request["instance_id"], None)
+                send(conn, {{"kind": "ack"}})
+            elif kind == "shutdown":
+                send(conn, {{"kind": "ack"}})
+                conn.close()
+                listener.close()
+                if os.path.exists(socket_path):
+                    os.remove(socket_path)
+                return
+            else:
+                send(conn, {{"kind": "error", "message": "unknown kind"}})
+
+if __name__ == "__main__":
+    main()
+"#
+        );
+        fs::write(&script_path, script).expect("write mock plugin host script");
+        script_path
+    }
+
+    fn au_engine(processor_id: &str, script_path: &PathBuf) -> Engine {
+        let mut profile = Profile::default();
+        profile.virtual_devices.outputs.push(VirtualOutputDevice {
+            id: "src".to_string(),
+            name: "Src".to_string(),
+            channels: Some(2),
+            uid: None,
+            hidden: false,
+        });
+        profile.virtual_devices.inputs.push(VirtualInputDevice {
+            id: "sink".to_string(),
+            name: "Sink".to_string(),
+            channels: Some(2),
+            uid: None,
+            mix: None,
+        });
+        profile.processors.push(ProcessorDefinition {
+            id: processor_id.to_string(),
+            kind: ProcessorKind::Au,
+            config: json!({
+                "api": "auv2",
+                "component_type": "aufx",
+                "component_subtype": "gain",
+                "component_manufacturer": "appl",
+                "process_timeout_ms": 25,
+                "max_frames": 2048,
+                "host_command": "python3",
+                "host_args": [script_path.to_string_lossy().to_string()],
+            }),
+        });
+        profile.processor_chains.push(ProcessorChain {
+            id: "chain-au".to_string(),
+            processors: vec![processor_id.to_string()],
+        });
+        profile.routes.push(Route {
+            id: "route-au".to_string(),
+            from: "src".to_string(),
+            to: "sink".to_string(),
+            enabled: true,
+            matrix: RouteMatrix {
+                rows: 2,
+                cols: 2,
+                coefficients: vec![vec![1.0, 0.0], vec![0.0, 1.0]],
+            },
+            chain: Some("chain-au".to_string()),
+            gain_db: 0.0,
+            mute: false,
+            pan: 0.0,
+            delay_ms: 0.0,
+        });
+        let graph = build_routing_graph(&profile).expect("build graph");
+        Engine::new(EngineSnapshot {
+            graph,
+            sample_rate: 48_000,
+            buffer_frames: 256,
         })
     }
 
@@ -2096,6 +2377,100 @@ mod tests {
         let out4 = engine.render_cycle(frames, &silence).expect("cycle4");
         assert!(out3.sinks["sink"].iter().all(|sample| sample.abs() < 1e-9));
         assert!(out4.sinks["sink"].iter().all(|sample| sample.abs() < 1e-9));
+    }
+
+    #[test]
+    fn au_processor_applies_processed_samples_from_host() {
+        let script_path = write_mock_plugin_host_script(0, 0.5);
+        let engine = au_engine("au-main", &script_path);
+
+        let mut sources = HashMap::new();
+        sources.insert("src".to_string(), vec![0.8; 256 * 2]);
+        let mut observed = None;
+        for _ in 0..64 {
+            let output = engine.render_cycle(256, &sources).expect("render");
+            let sink = output.sinks.get("sink").expect("sink");
+            let mean = sink.iter().copied().sum::<f32>() / sink.len() as f32;
+            if mean < 0.7 {
+                observed = Some(mean);
+                break;
+            }
+            thread::sleep(Duration::from_millis(2));
+        }
+
+        let mean = observed.expect("plugin host did not return processed frames in time");
+        assert!(
+            mean > 0.3,
+            "processed mean should stay above silence floor, got {mean}"
+        );
+
+        let _ = fs::remove_file(script_path);
+    }
+
+    #[test]
+    fn au_processor_reload_rebinds_new_instance() {
+        let script_path = write_mock_plugin_host_script(0, 1.0);
+        let engine = au_engine("au-a", &script_path);
+
+        let mut sources = HashMap::new();
+        sources.insert("src".to_string(), vec![0.25; 256 * 2]);
+        for _ in 0..16 {
+            engine.render_cycle(256, &sources).expect("render");
+            thread::sleep(Duration::from_millis(2));
+        }
+        let before = engine.plugin_runtime_status();
+        assert_eq!(before.instances.len(), 1);
+
+        let replacement = au_engine("au-b", &script_path);
+        engine.swap_snapshot(EngineSnapshot {
+            graph: replacement.snapshot.load().graph.clone(),
+            sample_rate: 48_000,
+            buffer_frames: 256,
+        });
+
+        for _ in 0..16 {
+            engine.render_cycle(256, &sources).expect("render");
+            thread::sleep(Duration::from_millis(2));
+        }
+
+        let after = engine.plugin_runtime_status();
+        assert_eq!(after.instances.len(), 1);
+        assert_eq!(after.instances[0].id, "au-b");
+        assert!(after.instances[0].process_calls > 0);
+
+        let _ = fs::remove_file(script_path);
+    }
+
+    #[test]
+    fn au_processor_recovers_after_host_crash() {
+        let script_path = write_mock_plugin_host_script(1, 1.0);
+        let engine = au_engine("au-crash", &script_path);
+
+        let mut sources = HashMap::new();
+        sources.insert("src".to_string(), vec![0.1; 256 * 2]);
+        let mut observed_fault = false;
+        for _ in 0..80 {
+            engine.render_cycle(256, &sources).expect("render");
+            thread::sleep(Duration::from_millis(5));
+            let runtime = engine.plugin_runtime_status();
+            if runtime.restart_count > 0 || runtime.error_count > 0 {
+                observed_fault = true;
+                break;
+            }
+        }
+
+        let status = engine.plugin_runtime_status();
+        assert_eq!(status.instances.len(), 1);
+        assert!(
+            observed_fault,
+            "expected plugin host crash to produce restart or error counters: {status:?}"
+        );
+        assert!(
+            status.instances[0].process_calls > 0,
+            "expected AU processor to continue processing after crash recovery"
+        );
+
+        let _ = fs::remove_file(script_path);
     }
 
     #[test]

--- a/crates/mars-plugin-host/Cargo.toml
+++ b/crates/mars-plugin-host/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "mars-plugin-host"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+mars-types = { path = "../mars-types" }
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/mars-plugin-host/src/main.rs
+++ b/crates/mars-plugin-host/src/main.rs
@@ -1,0 +1,252 @@
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeMap;
+use std::env;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
+
+use mars_types::{
+    AuPluginConfig, PLUGIN_HOST_PROTOCOL_VERSION, PluginHostRequest, PluginHostResponse,
+};
+
+#[derive(Debug, Clone)]
+struct LoadedInstance {
+    config: AuPluginConfig,
+    prepared: bool,
+    sample_rate: u32,
+    channels: u16,
+    max_frames: u32,
+}
+
+fn parse_socket_path() -> Result<PathBuf, String> {
+    let mut args = env::args().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--socket" {
+            let Some(path) = args.next() else {
+                return Err("missing path after --socket".to_string());
+            };
+            return Ok(PathBuf::from(path));
+        }
+    }
+    Err("missing required --socket argument".to_string())
+}
+
+fn send_response(stream: &mut UnixStream, response: &PluginHostResponse) -> Result<(), String> {
+    let mut payload = serde_json::to_string(response)
+        .map_err(|error| format!("failed to serialize response: {error}"))?;
+    payload.push('\n');
+    stream
+        .write_all(payload.as_bytes())
+        .map_err(|error| format!("failed to write response: {error}"))?;
+    stream
+        .flush()
+        .map_err(|error| format!("failed to flush response: {error}"))
+}
+
+fn error_response(message: impl Into<String>) -> PluginHostResponse {
+    PluginHostResponse::Error {
+        message: message.into(),
+    }
+}
+
+fn handle_request(
+    request: PluginHostRequest,
+    instances: &mut BTreeMap<String, LoadedInstance>,
+    process_count: &mut u64,
+    crash_after_process: Option<u64>,
+    process_delay: Duration,
+) -> PluginHostResponse {
+    match request {
+        PluginHostRequest::Handshake { protocol_version } => {
+            if protocol_version != PLUGIN_HOST_PROTOCOL_VERSION {
+                return error_response(format!(
+                    "protocol version mismatch: expected {PLUGIN_HOST_PROTOCOL_VERSION}, got {protocol_version}"
+                ));
+            }
+            PluginHostResponse::Handshake {
+                protocol_version: PLUGIN_HOST_PROTOCOL_VERSION,
+            }
+        }
+        PluginHostRequest::Load {
+            instance_id,
+            config,
+        } => {
+            instances.insert(
+                instance_id,
+                LoadedInstance {
+                    config,
+                    prepared: false,
+                    sample_rate: 0,
+                    channels: 0,
+                    max_frames: 0,
+                },
+            );
+            PluginHostResponse::Ack
+        }
+        PluginHostRequest::Prepare {
+            instance_id,
+            sample_rate,
+            channels,
+            max_frames,
+        } => {
+            let Some(instance) = instances.get_mut(&instance_id) else {
+                return error_response(format!("instance '{instance_id}' is not loaded"));
+            };
+            if channels == 0 {
+                return error_response("channels must be > 0".to_string());
+            }
+            if max_frames == 0 {
+                return error_response("max_frames must be > 0".to_string());
+            }
+            if max_frames > instance.config.max_frames {
+                return error_response(format!(
+                    "max_frames exceeds configured limit: requested={max_frames}, configured={}",
+                    instance.config.max_frames
+                ));
+            }
+            instance.prepared = true;
+            instance.sample_rate = sample_rate;
+            instance.channels = channels;
+            instance.max_frames = max_frames;
+            PluginHostResponse::Ack
+        }
+        PluginHostRequest::Process {
+            instance_id,
+            channels,
+            frames,
+            samples,
+        } => {
+            let Some(instance) = instances.get(&instance_id) else {
+                return error_response(format!("instance '{instance_id}' is not loaded"));
+            };
+            if !instance.prepared {
+                return error_response(format!("instance '{instance_id}' is not prepared"));
+            }
+            if channels != instance.channels {
+                return error_response(format!(
+                    "channel mismatch for '{instance_id}': expected {}, got {channels}",
+                    instance.channels
+                ));
+            }
+            if frames > instance.max_frames {
+                return error_response(format!(
+                    "frame count exceeds prepared max_frames: frames={frames}, max_frames={}",
+                    instance.max_frames
+                ));
+            }
+            let expected = (channels as usize).saturating_mul(frames as usize);
+            if samples.len() != expected {
+                return error_response(format!(
+                    "sample count mismatch: expected {expected}, got {}",
+                    samples.len()
+                ));
+            }
+
+            if !process_delay.is_zero() {
+                thread::sleep(process_delay);
+            }
+
+            *process_count = process_count.saturating_add(1);
+            if let Some(crash_after) = crash_after_process {
+                if *process_count >= crash_after {
+                    std::process::exit(77);
+                }
+            }
+
+            PluginHostResponse::Processed { samples }
+        }
+        PluginHostRequest::Reset { instance_id } => {
+            let Some(instance) = instances.get_mut(&instance_id) else {
+                return error_response(format!("instance '{instance_id}' is not loaded"));
+            };
+            instance.prepared = false;
+            PluginHostResponse::Ack
+        }
+        PluginHostRequest::Unload { instance_id } => {
+            instances.remove(&instance_id);
+            PluginHostResponse::Ack
+        }
+        PluginHostRequest::Shutdown => PluginHostResponse::Ack,
+    }
+}
+
+fn run_server(socket_path: PathBuf) -> Result<(), String> {
+    if socket_path.exists() {
+        let _ = std::fs::remove_file(&socket_path);
+    }
+
+    let listener = UnixListener::bind(&socket_path)
+        .map_err(|error| format!("failed to bind {}: {error}", socket_path.display()))?;
+
+    let crash_after_process = env::var("MARS_PLUGIN_HOST_CRASH_AFTER_PROCESS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0);
+    let process_delay = env::var("MARS_PLUGIN_HOST_PROCESS_DELAY_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or_default();
+
+    let (mut stream, _) = listener
+        .accept()
+        .map_err(|error| format!("failed to accept plugin host connection: {error}"))?;
+    let reader_stream = stream
+        .try_clone()
+        .map_err(|error| format!("failed to clone plugin host stream: {error}"))?;
+    let mut reader = BufReader::new(reader_stream);
+
+    let mut instances = BTreeMap::<String, LoadedInstance>::new();
+    let mut process_count = 0u64;
+    loop {
+        let mut line = String::new();
+        let bytes = reader
+            .read_line(&mut line)
+            .map_err(|error| format!("failed to read plugin host request: {error}"))?;
+        if bytes == 0 {
+            break;
+        }
+
+        let request = match serde_json::from_str::<PluginHostRequest>(&line) {
+            Ok(request) => request,
+            Err(error) => {
+                send_response(
+                    &mut stream,
+                    &error_response(format!("invalid plugin host request: {error}")),
+                )?;
+                continue;
+            }
+        };
+
+        let shutdown = matches!(request, PluginHostRequest::Shutdown);
+        let response = handle_request(
+            request,
+            &mut instances,
+            &mut process_count,
+            crash_after_process,
+            process_delay,
+        );
+        send_response(&mut stream, &response)?;
+
+        if shutdown {
+            break;
+        }
+    }
+
+    let _ = std::fs::remove_file(&socket_path);
+    Ok(())
+}
+
+fn main() {
+    let exit = match parse_socket_path().and_then(run_server) {
+        Ok(()) => 0,
+        Err(error) => {
+            eprintln!("{error}");
+            1
+        }
+    };
+    std::process::exit(exit);
+}

--- a/crates/mars-profile/src/lib.rs
+++ b/crates/mars-profile/src/lib.rs
@@ -6,7 +6,10 @@ use std::fs;
 use std::path::Path;
 
 use mars_graph::{GraphError, RoutingGraph, build_routing_graph};
-use mars_types::{AutoOrU16, AutoOrU32, PROFILE_VERSION, ProcessorKind, Profile, ValidationReport};
+use mars_types::{
+    AuPluginApi, AuPluginConfig, AutoOrU16, AutoOrU32, PROFILE_VERSION, ProcessorKind, Profile,
+    ValidationReport,
+};
 use regex::Regex;
 use schemars::schema_for;
 use thiserror::Error;
@@ -127,6 +130,11 @@ pub enum ProfileError {
     },
     #[error("processor '{processor_id}' time-shift config is invalid: {reason}")]
     InvalidTimeShiftConfig {
+        processor_id: String,
+        reason: String,
+    },
+    #[error("processor '{processor_id}' au config is invalid: {reason}")]
+    InvalidAuConfig {
         processor_id: String,
         reason: String,
     },
@@ -601,6 +609,73 @@ fn validate_time_shift_config(
     Ok(())
 }
 
+fn validate_au_config(config: &AuPluginConfig, processor_id: &str) -> Result<(), ProfileError> {
+    let non_empty = |value: &str| !value.trim().is_empty();
+    if config.process_timeout_ms == 0 || config.process_timeout_ms > 500 {
+        return Err(ProfileError::InvalidAuConfig {
+            processor_id: processor_id.to_string(),
+            reason: "process_timeout_ms must be in [1, 500]".to_string(),
+        });
+    }
+    if config.max_frames < 64 || config.max_frames > 8_192 {
+        return Err(ProfileError::InvalidAuConfig {
+            processor_id: processor_id.to_string(),
+            reason: "max_frames must be in [64, 8192]".to_string(),
+        });
+    }
+    if config.host_command.contains('\n') || config.host_command.contains('\r') {
+        return Err(ProfileError::InvalidAuConfig {
+            processor_id: processor_id.to_string(),
+            reason: "host_command must not contain line breaks".to_string(),
+        });
+    }
+    for (index, argument) in config.host_args.iter().enumerate() {
+        if argument.contains('\n') || argument.contains('\r') {
+            return Err(ProfileError::InvalidAuConfig {
+                processor_id: processor_id.to_string(),
+                reason: format!("host_args[{index}] must not contain line breaks"),
+            });
+        }
+    }
+
+    match config.api {
+        AuPluginApi::Auv2 => {
+            let fields = [
+                ("component_type", config.component_type.as_str()),
+                ("component_subtype", config.component_subtype.as_str()),
+                (
+                    "component_manufacturer",
+                    config.component_manufacturer.as_str(),
+                ),
+            ];
+            for (name, value) in fields {
+                if !non_empty(value) {
+                    return Err(ProfileError::InvalidAuConfig {
+                        processor_id: processor_id.to_string(),
+                        reason: format!("{name} must not be empty for auv2"),
+                    });
+                }
+                if value.chars().count() != 4 {
+                    return Err(ProfileError::InvalidAuConfig {
+                        processor_id: processor_id.to_string(),
+                        reason: format!("{name} must be a 4-character code for auv2"),
+                    });
+                }
+            }
+        }
+        AuPluginApi::Auv3 => {
+            if !non_empty(&config.bundle_id) {
+                return Err(ProfileError::InvalidAuConfig {
+                    processor_id: processor_id.to_string(),
+                    reason: "bundle_id must not be empty for auv3".to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn normalized_processor_config(config: &serde_json::Value) -> serde_json::Value {
     if config.is_null() {
         return serde_json::Value::Object(serde_json::Map::new());
@@ -651,7 +726,16 @@ fn validate_processor_chains(profile: &Profile) -> Result<(), ProfileError> {
                 })?;
                 validate_time_shift_config(&config, &processor.id)?;
             }
-            _ => {}
+            ProcessorKind::Au => {
+                let config = serde_json::from_value::<AuPluginConfig>(normalized_processor_config(
+                    &processor.config,
+                ))
+                .map_err(|error| ProfileError::InvalidAuConfig {
+                    processor_id: processor.id.clone(),
+                    reason: error.to_string(),
+                })?;
+                validate_au_config(&config, &processor.id)?;
+            }
         }
     }
 
@@ -1712,6 +1796,78 @@ pipes: []
         let err = validate_profile(profile).expect_err("validation must fail");
         assert!(err.to_string().contains("time-shift config is invalid"));
         assert!(err.to_string().contains("delay_ms must be <= max_delay_ms"));
+    }
+
+    #[test]
+    fn accepts_valid_auv2_processor_config() {
+        let yaml = r#"
+version: 2
+virtual:
+  outputs: []
+  inputs: []
+processors:
+  - id: au1
+    kind: au
+    config:
+      api: auv2
+      component_type: aufx
+      component_subtype: gain
+      component_manufacturer: appl
+      process_timeout_ms: 8
+      max_frames: 2048
+pipes: []
+"#;
+        let profile = parse_profile_str(yaml).expect("yaml parse should work");
+        validate_profile(profile).expect("validation should pass");
+    }
+
+    #[test]
+    fn accepts_valid_auv3_processor_config() {
+        let yaml = r#"
+version: 2
+virtual:
+  outputs: []
+  inputs: []
+processors:
+  - id: au3
+    kind: au
+    config:
+      api: auv3
+      bundle_id: com.example.unit
+      process_timeout_ms: 10
+      max_frames: 1024
+pipes: []
+"#;
+        let profile = parse_profile_str(yaml).expect("yaml parse should work");
+        validate_profile(profile).expect("validation should pass");
+    }
+
+    #[test]
+    fn rejects_invalid_auv2_processor_config() {
+        let yaml = r#"
+version: 2
+virtual:
+  outputs: []
+  inputs: []
+processors:
+  - id: au-invalid
+    kind: au
+    config:
+      api: auv2
+      component_type: aufx
+      component_subtype: bad
+      component_manufacturer: appl
+      process_timeout_ms: 0
+      max_frames: 32
+pipes: []
+"#;
+        let profile = parse_profile_str(yaml).expect("yaml parse should work");
+        let err = validate_profile(profile).expect_err("validation must fail");
+        assert!(err.to_string().contains("au config is invalid"));
+        assert!(
+            err.to_string()
+                .contains("process_timeout_ms must be in [1, 500]")
+        );
     }
 
     #[test]

--- a/crates/mars-types/src/lib.rs
+++ b/crates/mars-types/src/lib.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 pub const PROFILE_VERSION: u32 = 2;
+pub const PLUGIN_HOST_PROTOCOL_VERSION: u16 = 1;
 pub const PROFILE_FILE_EXTENSION: &str = "yaml";
 pub const MANAGED_UID_PREFIX: &str = "com.mars.";
 pub const MANUFACTURER_MARS: &str = "MARS";
@@ -393,6 +394,92 @@ pub enum ProcessorKind {
     Au,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AuPluginApi {
+    #[default]
+    Auv2,
+    Auv3,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct AuPluginConfig {
+    pub api: AuPluginApi,
+    pub component_type: String,
+    pub component_subtype: String,
+    pub component_manufacturer: String,
+    pub bundle_id: String,
+    pub process_timeout_ms: u32,
+    pub max_frames: u32,
+    pub host_command: String,
+    pub host_args: Vec<String>,
+}
+
+impl Default for AuPluginConfig {
+    fn default() -> Self {
+        Self {
+            api: AuPluginApi::Auv2,
+            component_type: String::new(),
+            component_subtype: String::new(),
+            component_manufacturer: String::new(),
+            bundle_id: String::new(),
+            process_timeout_ms: default_au_process_timeout_ms(),
+            max_frames: default_au_max_frames(),
+            host_command: String::new(),
+            host_args: Vec::new(),
+        }
+    }
+}
+
+const fn default_au_process_timeout_ms() -> u32 {
+    8
+}
+
+const fn default_au_max_frames() -> u32 {
+    2_048
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PluginHostRequest {
+    Handshake {
+        protocol_version: u16,
+    },
+    Load {
+        instance_id: String,
+        config: AuPluginConfig,
+    },
+    Prepare {
+        instance_id: String,
+        sample_rate: u32,
+        channels: u16,
+        max_frames: u32,
+    },
+    Process {
+        instance_id: String,
+        channels: u16,
+        frames: u32,
+        samples: Vec<f32>,
+    },
+    Reset {
+        instance_id: String,
+    },
+    Unload {
+        instance_id: String,
+    },
+    Shutdown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PluginHostResponse {
+    Handshake { protocol_version: u16 },
+    Ack,
+    Processed { samples: Vec<f32> },
+    Error { message: String },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ProcessorChain {
@@ -769,6 +856,52 @@ pub struct SinkRuntimeStatus {
     pub sinks: Vec<SinkRuntimeSinkStatus>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PluginHostHealth {
+    #[default]
+    Healthy,
+    Degraded,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+pub struct PluginHostInstanceStatus {
+    pub id: String,
+    pub api: AuPluginApi,
+    pub health: PluginHostHealth,
+    #[serde(default)]
+    pub loaded: bool,
+    #[serde(default)]
+    pub host_pid: Option<u32>,
+    #[serde(default)]
+    pub process_calls: u64,
+    #[serde(default)]
+    pub timeout_count: u64,
+    #[serde(default)]
+    pub error_count: u64,
+    #[serde(default)]
+    pub restart_count: u64,
+    #[serde(default)]
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+pub struct PluginHostRuntimeStatus {
+    #[serde(default)]
+    pub active_instances: usize,
+    #[serde(default)]
+    pub failed_instances: usize,
+    #[serde(default)]
+    pub timeout_count: u64,
+    #[serde(default)]
+    pub error_count: u64,
+    #[serde(default)]
+    pub restart_count: u64,
+    #[serde(default)]
+    pub instances: Vec<PluginHostInstanceStatus>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct DeviceDescriptor {
     pub id: String,
@@ -802,6 +935,8 @@ pub struct DaemonStatus {
     pub capture_runtime: CaptureRuntimeStatus,
     #[serde(default)]
     pub sink_runtime: SinkRuntimeStatus,
+    #[serde(default)]
+    pub plugin_runtime: PluginHostRuntimeStatus,
     pub updated_at: DateTime<Utc>,
 }
 
@@ -833,6 +968,16 @@ pub struct DoctorReport {
     pub sink_failed: usize,
     #[serde(default)]
     pub sink_write_errors: u64,
+    #[serde(default)]
+    pub plugin_active: usize,
+    #[serde(default)]
+    pub plugin_failed: usize,
+    #[serde(default)]
+    pub plugin_timeouts: u64,
+    #[serde(default)]
+    pub plugin_errors: u64,
+    #[serde(default)]
+    pub plugin_restarts: u64,
     #[serde(default)]
     pub notes: Vec<String>,
 }


### PR DESCRIPTION
## Summary
- add an isolated `mars-plugin-host` process with a strict JSON IPC lifecycle (`handshake/load/prepare/process/reset/unload/shutdown`)
- wire `ProcessorKind::Au` to a dedicated AU runtime bridge in `mars-engine` with non-blocking RT submission, fault isolation, restart/error accounting, and daemon/doctor status propagation
- extend Profile v2 AU config validation and daemon/CLI observability for plugin host runtime health
- add AU host integration tests (reload + crash recovery), plugin-host benchmarks, benchmark budgets, and CI benchmark gates on macOS 15

## Validation
- `cargo fmt`
- `cargo test -p mars-engine`
- `cargo test -p mars-cli`
- `cargo test -p mars-types -p mars-profile -p mars-daemon -p mars-plugin-host`
- `scripts/bench/verify.sh --platform macos-15 --bench-cmd "cargo bench -p mars-engine --bench plugin_host" --benchmark-prefix "engine/au/"`

Closes #13
