### PR TITLE
feat: add mars-sdk crate and docs; misc fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mars-sdk"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "dirs",
+ "mars-ipc",
+ "mars-types",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "mars-shm"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "crates/mars-types",
   "crates/mars-profile",
   "crates/mars-graph",
+  "crates/mars-sdk",
   "crates/mars-shm",
   "crates/mars-engine",
   "crates/mars-coreaudio",

--- a/README.md
+++ b/README.md
@@ -1,13 +1,23 @@
 # MARS
 
-MARS (macOS Audio Router Service) is an audio routing system for macOS.
+MARS (macOS Audio Router Service) is an audio routing system for macOS 15+.
 
 ## What is included
 
-- `mars` CLI with commands: `create`, `open`, `apply`, `clear`, `validate`, `plan`, `status`, `devices`, `test`, `logs`, `doctor`
+- `mars` CLI with commands: `create`, `open`, `apply`, `clear`, `validate`, `plan`, `status`, `devices`, `processes`, `test`, `logs`, `doctor`
 - `marsd` daemon with declarative apply transaction and rollback semantics
+- `mars-sdk` Rust SDK crate for building external apps/tools on the typed MARS API
 - `mars-hal` AudioServerPlugIn driver crate and `mars.driver` bundle scaffold
+- Profile schema `version: 2` only (`version: 1` is rejected)
+- Process/system capture tap model (`captures.process_taps` and `captures.system_taps`)
+- Built-in file sinks (`sinks.files`) for WAV/CAF recording
+- AUv2/AUv3 processor hosting through isolated `mars-plugin-host`
 - Shared profile schema, graph validator, ring-buffer model, and realtime engine core
+
+## Current limitations
+
+- `sinks.streams` is an extensible descriptor model, but stream sink runtime is not implemented yet.
+- When a stream sink is configured, runtime status/doctor surfaces it as failed with `last_error` details.
 
 ## Architecture
 
@@ -109,6 +119,7 @@ graph BT
     halclient["mars-hal-client<br/><i>safe driver API</i>"]
     shm["mars-shm<br/><i>ring buffer facade</i>"]
     ipc["mars-ipc<br/><i>Unix socket protocol</i>"]
+    sdk["mars-sdk<br/><i>public app SDK</i>"]
     daemon["mars-daemon<br/><i>marsd orchestrator</i>"]
     cli["mars-cli<br/><i>user interface</i>"]
 
@@ -121,6 +132,8 @@ graph BT
     shm --> hal
     halclient --> hal
     ipc --> types
+    sdk --> types
+    sdk --> ipc
     daemon --> profile
     daemon --> engine
     daemon --> coreaudio
@@ -132,7 +145,7 @@ graph BT
     cli --> ipc
 
     class types foundation
-    class graph_,profile,engine,ipc core
+    class graph_,profile,engine,ipc,sdk core
     class hal,halclient,shm,coreaudio platform
     class daemon,cli app
 ```
@@ -214,9 +227,14 @@ sudo killall -9 coreaudiod
 
 ## Usage
 
+The default template includes process/system taps and a stream sink descriptor. Before `mars apply`, update or remove those entries so they match your host:
+- use `mars processes --json` to select real process selectors (PID or bundle id)
+- remove `captures` or `sinks.streams` entries you do not need
+
 ```bash
 mars create demo
 mars open demo
+mars processes --json
 mars validate demo
 mars plan demo
 mars apply demo
@@ -230,6 +248,13 @@ mars clear
 
 `mars test` measures internal MARS data-plane latency only.
 `mars test --route` verifies the microphone-to-speaker and microphone-to-virtual-capture route.
+
+## SDK
+
+For third-party app/tool development, use the Rust SDK:
+
+- docs: `docs/sdk.md`
+- example: `cargo run -p mars-sdk --example status`
 
 ## Uninstall
 

--- a/crates/mars-coreaudio/src/lib.rs
+++ b/crates/mars-coreaudio/src/lib.rs
@@ -1062,18 +1062,15 @@ pub struct ExternalRuntimeSnapshot {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default)]
 pub enum ExternalEndpointHealth {
     Connected,
     Degraded,
     Reconnecting,
+    #[default]
     Stopped,
 }
 
-impl Default for ExternalEndpointHealth {
-    fn default() -> Self {
-        Self::Stopped
-    }
-}
 
 #[derive(Debug, Clone, Default)]
 pub struct ExternalInputEndpointSnapshot {

--- a/crates/mars-engine/src/lib.rs
+++ b/crates/mars-engine/src/lib.rs
@@ -1445,13 +1445,12 @@ impl Engine {
             };
 
             if let Some(mix) = node.mix.as_ref() {
-                if matches!(mix.mode, MixMode::Average) {
-                    if contribution_count > 1 {
+                if matches!(mix.mode, MixMode::Average)
+                    && contribution_count > 1 {
                         for sample in buffer.iter_mut() {
                             *sample /= contribution_count as f32;
                         }
                     }
-                }
 
                 if mix.limiter {
                     apply_soft_limiter(buffer, mix.limit_dbfs);

--- a/crates/mars-sdk/Cargo.toml
+++ b/crates/mars-sdk/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "mars-sdk"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+description = "Public Rust SDK for building apps and tools on top of marsd"
+keywords = ["audio", "routing", "sdk", "ipc", "macos"]
+categories = ["api-bindings", "multimedia::audio"]
+
+[features]
+default = ["default-socket-path"]
+default-socket-path = ["dep:dirs"]
+
+[lints]
+workspace = true
+
+[dependencies]
+dirs = { workspace = true, optional = true }
+mars-ipc = { path = "../mars-ipc" }
+mars-types = { path = "../mars-types" }
+thiserror.workspace = true
+
+[dev-dependencies]
+chrono.workspace = true
+tokio.workspace = true
+
+[[example]]
+name = "status"
+path = "examples/status.rs"
+required-features = ["default-socket-path"]

--- a/crates/mars-sdk/examples/status.rs
+++ b/crates/mars-sdk/examples/status.rs
@@ -1,0 +1,15 @@
+use mars_sdk::MarsClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = MarsClient::new_default(MarsClient::default_timeout())?;
+    client.ping().await?;
+
+    let status = client.status().await?;
+    println!(
+        "running={} profile={:?}",
+        status.running, status.current_profile
+    );
+
+    Ok(())
+}

--- a/crates/mars-sdk/src/lib.rs
+++ b/crates/mars-sdk/src/lib.rs
@@ -1,0 +1,405 @@
+#![forbid(unsafe_code)]
+//! High-level async SDK for building applications and tools on top of MARS.
+//!
+//! `MarsClient` wraps the low-level IPC transport and exposes typed operations
+//! matching the public daemon contract.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use mars_ipc::{Command, DaemonRequest, DaemonResponse, IpcClient};
+pub use mars_ipc::{IpcError, LogRequest, LogResponse};
+pub use mars_types::{
+    ApplyPlan, ApplyRequest, ApplyResult, CaptureProcessInfo, ClearRequest,
+    DEFAULT_SOCKET_PATH_RELATIVE, DaemonStatus, DeviceInventory, DoctorReport, ExitCode,
+    PlanRequest, ValidateRequest, ValidationReport,
+};
+use thiserror::Error;
+
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ApplyOptions {
+    pub no_delete: bool,
+    pub dry_run: bool,
+    pub timeout_ms: u64,
+}
+
+impl Default for ApplyOptions {
+    fn default() -> Self {
+        Self {
+            no_delete: false,
+            dry_run: false,
+            timeout_ms: 5_000,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum MarsClientError {
+    #[error("ipc error: {0}")]
+    Ipc(#[from] IpcError),
+
+    #[cfg(feature = "default-socket-path")]
+    #[error("cannot determine home directory for default MARS socket path")]
+    HomeDirectoryUnavailable,
+
+    #[error("profile path is not valid UTF-8: {0}")]
+    NonUtf8Path(PathBuf),
+
+    #[error("daemon returned unexpected response: expected {expected:?}, got {actual:?}")]
+    UnexpectedResponse { expected: Command, actual: Command },
+}
+
+#[derive(Debug, Clone)]
+pub struct MarsClient {
+    socket_path: PathBuf,
+    timeout: Duration,
+    ipc: IpcClient,
+}
+
+impl MarsClient {
+    #[must_use]
+    pub fn new(socket_path: PathBuf, timeout: Duration) -> Self {
+        Self {
+            ipc: IpcClient::new(socket_path.clone(), timeout),
+            socket_path,
+            timeout,
+        }
+    }
+
+    #[cfg(feature = "default-socket-path")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "default-socket-path")))]
+    pub fn new_default(timeout: Duration) -> Result<Self, MarsClientError> {
+        let socket_path = Self::default_socket_path()?;
+        Ok(Self::new(socket_path, timeout))
+    }
+
+    #[cfg(feature = "default-socket-path")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "default-socket-path")))]
+    pub fn default_socket_path() -> Result<PathBuf, MarsClientError> {
+        let home = dirs::home_dir().ok_or(MarsClientError::HomeDirectoryUnavailable)?;
+        Ok(home.join(DEFAULT_SOCKET_PATH_RELATIVE))
+    }
+
+    #[must_use]
+    pub const fn default_timeout() -> Duration {
+        DEFAULT_REQUEST_TIMEOUT
+    }
+
+    #[must_use]
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    #[must_use]
+    pub const fn timeout(&self) -> Duration {
+        self.timeout
+    }
+
+    pub async fn ping(&self) -> Result<(), MarsClientError> {
+        match self.ipc.send(DaemonRequest::Ping).await? {
+            DaemonResponse::Pong => Ok(()),
+            other => Err(unexpected_response(Command::Ping, &other)),
+        }
+    }
+
+    pub async fn validate(
+        &self,
+        request: ValidateRequest,
+    ) -> Result<ValidationReport, MarsClientError> {
+        match self.ipc.send(DaemonRequest::Validate(request)).await? {
+            DaemonResponse::Validate(report) => Ok(report),
+            other => Err(unexpected_response(Command::Validate, &other)),
+        }
+    }
+
+    pub async fn validate_profile(
+        &self,
+        profile_path: impl AsRef<Path>,
+    ) -> Result<ValidationReport, MarsClientError> {
+        self.validate(ValidateRequest {
+            profile_path: path_to_utf8(profile_path.as_ref())?,
+        })
+        .await
+    }
+
+    pub async fn plan(&self, request: PlanRequest) -> Result<ApplyPlan, MarsClientError> {
+        match self.ipc.send(DaemonRequest::Plan(request)).await? {
+            DaemonResponse::Plan(plan) => Ok(plan),
+            other => Err(unexpected_response(Command::Plan, &other)),
+        }
+    }
+
+    pub async fn plan_profile(
+        &self,
+        profile_path: impl AsRef<Path>,
+        no_delete: bool,
+    ) -> Result<ApplyPlan, MarsClientError> {
+        self.plan(PlanRequest {
+            profile_path: path_to_utf8(profile_path.as_ref())?,
+            no_delete,
+        })
+        .await
+    }
+
+    pub async fn apply(&self, request: ApplyRequest) -> Result<ApplyResult, MarsClientError> {
+        match self.ipc.send(DaemonRequest::Apply(request)).await? {
+            DaemonResponse::Apply(result) => Ok(result),
+            other => Err(unexpected_response(Command::Apply, &other)),
+        }
+    }
+
+    pub async fn apply_profile(
+        &self,
+        profile_path: impl AsRef<Path>,
+        options: ApplyOptions,
+    ) -> Result<ApplyResult, MarsClientError> {
+        self.apply(ApplyRequest {
+            profile_path: path_to_utf8(profile_path.as_ref())?,
+            no_delete: options.no_delete,
+            dry_run: options.dry_run,
+            timeout_ms: options.timeout_ms,
+        })
+        .await
+    }
+
+    pub async fn clear(&self, keep_devices: bool) -> Result<ApplyResult, MarsClientError> {
+        match self
+            .ipc
+            .send(DaemonRequest::Clear(ClearRequest { keep_devices }))
+            .await?
+        {
+            DaemonResponse::Clear(result) => Ok(result),
+            other => Err(unexpected_response(Command::Clear, &other)),
+        }
+    }
+
+    pub async fn status(&self) -> Result<DaemonStatus, MarsClientError> {
+        match self.ipc.send(DaemonRequest::Status).await? {
+            DaemonResponse::Status(status) => Ok(status),
+            other => Err(unexpected_response(Command::Status, &other)),
+        }
+    }
+
+    pub async fn devices(&self) -> Result<DeviceInventory, MarsClientError> {
+        match self.ipc.send(DaemonRequest::Devices).await? {
+            DaemonResponse::Devices(devices) => Ok(devices),
+            other => Err(unexpected_response(Command::Devices, &other)),
+        }
+    }
+
+    pub async fn processes(&self) -> Result<Vec<CaptureProcessInfo>, MarsClientError> {
+        match self.ipc.send(DaemonRequest::Processes).await? {
+            DaemonResponse::Processes(processes) => Ok(processes),
+            other => Err(unexpected_response(Command::Processes, &other)),
+        }
+    }
+
+    pub async fn logs(&self, request: LogRequest) -> Result<LogResponse, MarsClientError> {
+        match self.ipc.send(DaemonRequest::Logs(request)).await? {
+            DaemonResponse::Logs(response) => Ok(response),
+            other => Err(unexpected_response(Command::Logs, &other)),
+        }
+    }
+
+    pub async fn logs_once(
+        &self,
+        cursor: Option<u64>,
+        limit: Option<u32>,
+    ) -> Result<LogResponse, MarsClientError> {
+        self.logs(LogRequest {
+            follow: false,
+            cursor,
+            limit,
+        })
+        .await
+    }
+
+    pub async fn doctor(&self) -> Result<DoctorReport, MarsClientError> {
+        match self.ipc.send(DaemonRequest::Doctor).await? {
+            DaemonResponse::Doctor(report) => Ok(report),
+            other => Err(unexpected_response(Command::Doctor, &other)),
+        }
+    }
+}
+
+fn path_to_utf8(path: &Path) -> Result<String, MarsClientError> {
+    path.to_str()
+        .map(std::borrow::ToOwned::to_owned)
+        .ok_or_else(|| MarsClientError::NonUtf8Path(path.to_path_buf()))
+}
+
+fn unexpected_response(expected: Command, actual: &DaemonResponse) -> MarsClientError {
+    MarsClientError::UnexpectedResponse {
+        expected,
+        actual: response_command(actual),
+    }
+}
+
+const fn response_command(response: &DaemonResponse) -> Command {
+    match response {
+        DaemonResponse::Pong => Command::Ping,
+        DaemonResponse::Validate(_) => Command::Validate,
+        DaemonResponse::Plan(_) => Command::Plan,
+        DaemonResponse::Apply(_) => Command::Apply,
+        DaemonResponse::Clear(_) => Command::Clear,
+        DaemonResponse::Status(_) => Command::Status,
+        DaemonResponse::Devices(_) => Command::Devices,
+        DaemonResponse::Processes(_) => Command::Processes,
+        DaemonResponse::Logs(_) => Command::Logs,
+        DaemonResponse::Doctor(_) => Command::Doctor,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use chrono::Utc;
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+
+    use super::*;
+    use mars_types::{
+        CaptureRuntimeStatus, DriverStatusSummary, ExternalRuntimeStatus, PluginHostRuntimeStatus,
+        RuntimeCounters, SinkRuntimeStatus,
+    };
+
+    #[test]
+    fn apply_options_defaults_match_cli_defaults() {
+        let options = ApplyOptions::default();
+        assert!(!options.no_delete);
+        assert!(!options.dry_run);
+        assert_eq!(options.timeout_ms, 5_000);
+    }
+
+    #[test]
+    fn unexpected_response_includes_expected_and_actual_commands() {
+        let error = unexpected_response(Command::Status, &DaemonResponse::Pong);
+        assert!(matches!(
+            error,
+            MarsClientError::UnexpectedResponse {
+                expected: Command::Status,
+                actual: Command::Ping,
+            }
+        ));
+    }
+
+    #[test]
+    fn response_command_maps_all_variants() {
+        assert_eq!(response_command(&DaemonResponse::Pong), Command::Ping);
+        assert_eq!(
+            response_command(&DaemonResponse::Validate(ValidationReport {
+                valid: true,
+                warnings: Vec::new(),
+                errors: Vec::new(),
+            })),
+            Command::Validate
+        );
+        assert_eq!(
+            response_command(&DaemonResponse::Plan(ApplyPlan::default())),
+            Command::Plan
+        );
+        assert_eq!(
+            response_command(&DaemonResponse::Apply(ApplyResult {
+                applied: true,
+                plan: ApplyPlan::default(),
+                warnings: Vec::new(),
+                errors: Vec::new(),
+            })),
+            Command::Apply
+        );
+        assert_eq!(
+            response_command(&DaemonResponse::Clear(ApplyResult {
+                applied: false,
+                plan: ApplyPlan::default(),
+                warnings: Vec::new(),
+                errors: Vec::new(),
+            })),
+            Command::Clear
+        );
+        assert_eq!(
+            response_command(&DaemonResponse::Status(DaemonStatus {
+                running: false,
+                current_profile: None,
+                sample_rate: 48_000,
+                buffer_frames: 256,
+                graph_pipe_count: 0,
+                graph_route_count: 0,
+                devices: Vec::new(),
+                counters: RuntimeCounters::default(),
+                processor_runtime: std::collections::BTreeMap::new(),
+                driver: DriverStatusSummary::default(),
+                external_runtime: ExternalRuntimeStatus::default(),
+                capture_runtime: CaptureRuntimeStatus::default(),
+                sink_runtime: SinkRuntimeStatus::default(),
+                plugin_runtime: PluginHostRuntimeStatus::default(),
+                updated_at: Utc::now(),
+            })),
+            Command::Status
+        );
+        assert_eq!(
+            response_command(&DaemonResponse::Devices(DeviceInventory {
+                inputs: Vec::new(),
+                outputs: Vec::new(),
+            })),
+            Command::Devices
+        );
+        assert_eq!(
+            response_command(&DaemonResponse::Processes(Vec::new())),
+            Command::Processes
+        );
+        assert_eq!(
+            response_command(&DaemonResponse::Logs(LogResponse {
+                lines: Vec::new(),
+                next_cursor: 0,
+            })),
+            Command::Logs
+        );
+        assert_eq!(
+            response_command(&DaemonResponse::Doctor(DoctorReport {
+                driver_installed: true,
+                driver_compatible: true,
+                daemon_reachable: true,
+                microphone_permission_ok: true,
+                driver_version: Some("0.1.0".to_string()),
+                daemon_version: "0.1.0".to_string(),
+                mic_permission_source: "test".to_string(),
+                driver: DriverStatusSummary::default(),
+                capture_tap_supported: true,
+                capture_active_taps: 0,
+                capture_failed_taps: 0,
+                sink_active: 0,
+                sink_degraded: 0,
+                sink_failed: 0,
+                sink_write_errors: 0,
+                plugin_active: 0,
+                plugin_failed: 0,
+                plugin_timeouts: 0,
+                plugin_errors: 0,
+                plugin_restarts: 0,
+                notes: Vec::new(),
+            })),
+            Command::Doctor
+        );
+    }
+
+    #[cfg(feature = "default-socket-path")]
+    #[test]
+    fn default_socket_path_uses_known_relative_location() {
+        if let Ok(socket_path) = MarsClient::default_socket_path() {
+            assert!(socket_path.ends_with(DEFAULT_SOCKET_PATH_RELATIVE));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_utf8_path_is_rejected() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let path = PathBuf::from(OsString::from_vec(vec![0x66, 0x6f, 0x80]));
+        let error = path_to_utf8(&path).unwrap_err();
+
+        assert!(matches!(error, MarsClientError::NonUtf8Path(_)));
+    }
+}

--- a/docs/driver-compatibility-matrix.md
+++ b/docs/driver-compatibility-matrix.md
@@ -2,10 +2,15 @@
 
 | Component       | Minimum                       | Tested                | Notes                              |
 | --------------- | ----------------------------- | --------------------- | ---------------------------------- |
-| macOS           | 14.0                          | 15.x (Sequoia family) | Target is macOS 14+                |
+| macOS           | 15.0                          | 15.x (Sequoia family) | Target is macOS 15+                |
 | Xcode           | 16.0                          | 16.3                  | Required for native toolchain      |
 | Rust            | 1.87                          | 1.93                  | Workspace currently tested on 1.93 |
 | HAL bundle path | `/Library/Audio/Plug-Ins/HAL` | same                  | Requires admin privileges          |
+
+## Tap capability notes
+
+- Process/system capture taps depend on CoreAudio tap API support on macOS 15+ hosts.
+- Use `mars doctor` to verify tap capability on the current machine before enabling `captures.*` in profiles.
 
 ## Driver/daemon version check
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,10 +1,10 @@
 # MARS Getting Started
 
-This guide covers a full dev-first setup on macOS, from first install to first profile apply.
+This guide covers a full dev-first setup on macOS 15+, from first install to first profile apply.
 
 ## Prerequisites
 
-- macOS (MARS uses CoreAudio HAL and launchd user agents).
+- macOS 15+ (MARS uses CoreAudio HAL and launchd user agents).
 - Rust toolchain (`cargo`, `rustc`) available in your shell.
 - `sudo` access (needed for protected system paths like `/usr/local/bin` and `/Library/Audio/Plug-Ins/HAL`).
 - Run commands from the repository root.
@@ -46,9 +46,14 @@ mars doctor
 
 ## 3. Run Your First Profile
 
+The default template includes process/system taps and a stream sink descriptor. Before apply:
+- use `mars processes --json` to choose real process selectors on your host
+- remove or edit `captures`/`sinks.streams` entries you do not need
+
 ```bash
 mars create demo
 mars open demo
+mars processes --json
 mars validate demo
 mars plan demo
 mars apply demo

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -7,6 +7,7 @@ Default profile directory:
 - `~/Library/Application Support/mars/profiles/`
 
 A profile is addressed by file name stem (`<name>.yaml`).
+All active profiles must use `version: 2` (v1 is rejected).
 
 ## Core commands
 
@@ -33,7 +34,13 @@ A profile is addressed by file name stem (`<name>.yaml`).
   - `graph_route_count`
   - `processor_runtime` (per-processor prepare/process/reset counters)
   - `capture_runtime` and `sink_runtime` health/counter snapshots
+  - `plugin_runtime.*` (active/failed instances, timeout/error/restart counters, per-instance health)
+- `mars doctor --json` includes plugin host summary counters:
+  - `plugin_active`, `plugin_failed`, `plugin_timeouts`, `plugin_errors`, `plugin_restarts`
 - `mars processes --json` lists process object id, pid, bundle id, and running I/O flags for capture selector authoring.
+- Sink runtime capability boundary:
+  - `sinks.files` (WAV/CAF) is implemented.
+  - `sinks.streams` is currently descriptor-only; runtime marks stream sinks as failed with `last_error`.
 - `external_runtime.stream_errors` is capped (ring buffer) to avoid unbounded growth.
 
 ## Log cursor semantics

--- a/docs/performance-gates.md
+++ b/docs/performance-gates.md
@@ -51,11 +51,14 @@ scripts/bench/verify.sh --platform macos-15 \
   --bench-cmd "cargo bench -p mars-engine --bench engine -- engine/render_processor_block" \
   --bench-cmd "cargo bench -p mars-engine --bench engine -- engine/render_processor_chain_kind" \
   --bench-cmd "cargo bench -p mars-engine --bench engine -- engine/render_timeshift_depth" \
+  --bench-cmd "cargo bench -p mars-engine --bench plugin_host" \
   --benchmark-prefix "engine/render_chain_length/" \
   --benchmark-prefix "engine/render_param_updates/" \
   --benchmark-prefix "engine/render_processor_block/" \
   --benchmark-prefix "engine/render_processor_chain_kind/" \
-  --benchmark-prefix "engine/render_timeshift_depth/"
+  --benchmark-prefix "engine/render_timeshift_depth/" \
+  --benchmark-prefix "engine/au/ipc_overhead/" \
+  --benchmark-prefix "engine/au/plugin_latency/"
 ```
 
 ### Capture gate

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,0 +1,68 @@
+# MARS SDK (Rust)
+
+`mars-sdk` is the public Rust integration layer for building apps and tools on top of `marsd`.
+
+## Contract scope
+
+`mars-sdk` wraps the public daemon contract:
+
+- Protocol transport and envelopes from `mars-ipc`
+- Request/response types from `mars-types`
+- Typed async operations through `MarsClient`
+
+## Add dependency
+
+```toml
+[dependencies]
+mars-sdk = { path = "crates/mars-sdk" }
+```
+
+Feature notes:
+
+- default feature `default-socket-path` enables `MarsClient::new_default()` and uses `dirs` to resolve `~/<cache>/mars/marsd.sock`.
+- disable defaults if your app always provides an explicit socket path:
+
+```toml
+[dependencies]
+mars-sdk = { path = "crates/mars-sdk", default-features = false }
+```
+
+## Quickstart
+
+```rust
+use mars_sdk::MarsClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = MarsClient::new_default(MarsClient::default_timeout())?;
+
+    client.ping().await?;
+    let status = client.status().await?;
+
+    println!("running={} profile={:?}", status.running, status.current_profile);
+    Ok(())
+}
+```
+
+## API summary
+
+- `MarsClient::new(socket_path, timeout)`
+- `MarsClient::new_default(timeout)`
+- `MarsClient::ping()`
+- `MarsClient::validate()/validate_profile()`
+- `MarsClient::plan()/plan_profile()`
+- `MarsClient::apply()/apply_profile()`
+- `MarsClient::clear()`
+- `MarsClient::status()`
+- `MarsClient::devices()`
+- `MarsClient::processes()`
+- `MarsClient::logs()/logs_once()`
+- `MarsClient::doctor()`
+
+## Example
+
+Run the bundled example:
+
+```bash
+cargo run -p mars-sdk --example status
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,6 +43,61 @@ Notes:
 - `manufacturer` / `transport` matching is best-effort when metadata is unavailable on the host.
 - If matching succeeded via unknown metadata, `plan` / `apply` warnings will mention it.
 
+## Process tap selector did not match any process object
+
+Symptom:
+
+- `process tap '<id>' selector '<selector>' did not match any active CoreAudio process object`
+
+Cause:
+
+- The configured PID or bundle id does not match current CoreAudio process objects.
+
+Fix:
+
+1. Run `mars processes --json`.
+2. Pick a selector that exists on the current host:
+   - `type: pid` for a specific running process.
+   - `type: bundle_id` for stable app matching.
+3. Update profile `captures.process_taps`, then re-run `mars validate` and `mars apply`.
+
+## Stream sink reports `not implemented`
+
+Symptom:
+
+- `stream sink not implemented for transport=...` appears in logs or sink status.
+
+Cause:
+
+- `sinks.streams` is descriptor-only in the current runtime; file sinks are implemented, stream sinks are not.
+
+Fix:
+
+1. Check runtime health:
+   - `mars status --json` -> `sink_runtime.sinks[].health` and `sink_runtime.sinks[].last_error`
+   - `mars doctor --json` -> `sink_failed` and `sink_write_errors`
+2. Remove or disable `sinks.streams` entries.
+3. Use `sinks.files` (`wav` or `caf`) for current recording output.
+
+## AU plugin host shows timeouts/errors/restarts
+
+Symptom:
+
+- `plugin_timeouts`, `plugin_errors`, or `plugin_restarts` is non-zero in `mars doctor --json`.
+
+Cause:
+
+- The isolated AU host (`mars-plugin-host`) hit timeout/restart/error conditions.
+
+Fix:
+
+1. Inspect counters:
+   - `mars status --json` -> `plugin_runtime.*` and `plugin_runtime.instances[]`
+   - `mars doctor --json` -> `plugin_active`, `plugin_failed`, `plugin_timeouts`, `plugin_errors`, `plugin_restarts`
+2. Check logs:
+   - `mars logs`
+3. Re-apply the profile after correcting AU config, then verify counters stabilize.
+
 ## External endpoint disconnects during runtime
 
 Cause:


### PR DESCRIPTION
Introduce a new mars-sdk Rust crate (Cargo.toml, src, example/status.rs) exposing MarsClient — a high-level async wrapper around mars-ipc/mars-types with convenience helpers (default socket path feature, request helpers, and tests). Add the crate to the workspace Cargo.toml. Update README and multiple docs (getting-started, operator-guide, driver-compatibility-matrix, performance-gates, troubleshooting) to document the SDK, target macOS 15+ requirements, process/system tap and stream-sink limitations, plugin host counters, and usage notes (e.g. using `mars processes --json`). Apply small code cleanups: derive Default for ExternalEndpointHealth instead of manual impl and simplify an if condition in the engine mix handling. Also add new benchmark prefixes for AU/plugin metrics.