### PR TITLE
feat(observability): optional OpenTelemetry for usage and realtime health

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,10 +134,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -489,6 +501,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,16 +552,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -553,7 +635,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -572,6 +658,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
@@ -581,6 +679,25 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -622,6 +739,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,10 +860,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -661,6 +977,22 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -745,6 +1077,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +1125,7 @@ dependencies = [
  "mars-coreaudio",
  "mars-ipc",
  "mars-profile",
+ "mars-telemetry",
  "mars-types",
  "serde",
  "serde_json",
@@ -826,6 +1165,7 @@ dependencies = [
  "mars-ipc",
  "mars-profile",
  "mars-shm",
+ "mars-telemetry",
  "mars-types",
  "once_cell",
  "parking_lot",
@@ -845,6 +1185,7 @@ dependencies = [
  "arc-swap",
  "criterion",
  "mars-graph",
+ "mars-telemetry",
  "mars-types",
  "parking_lot",
  "serde",
@@ -893,6 +1234,7 @@ name = "mars-ipc"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "mars-telemetry",
  "mars-types",
  "serde",
  "serde_json",
@@ -906,6 +1248,7 @@ dependencies = [
 name = "mars-plugin-host"
 version = "0.1.0"
 dependencies = [
+ "mars-telemetry",
  "mars-types",
  "serde",
  "serde_json",
@@ -944,6 +1287,17 @@ name = "mars-shm"
 version = "0.1.0"
 dependencies = [
  "mars-hal",
+]
+
+[[package]]
+name = "mars-telemetry"
+version = "0.1.0"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
@@ -1189,6 +1543,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1658,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,6 +1673,26 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "serde",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1286,10 +1742,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1320,6 +1794,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +1830,35 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rayon"
@@ -1422,6 +1948,40 @@ name = "regex-syntax"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "rustversion"
@@ -1537,6 +2097,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,6 +2169,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "stats_alloc"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,6 +2195,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1700,6 +2298,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,6 +2345,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,6 +2397,92 @@ checksum = "0742ff5ff03ea7e67c8ae6c93cac239e0d9784833362da3f9a9c1da8dfefcbdc"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project-lite",
+ "slab",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1840,6 +2558,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,6 +2580,24 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1889,6 +2631,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -2406,6 +3157,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,6 +3199,60 @@ name = "zerocopy-derive"
 version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "crates/mars-types",
   "crates/mars-profile",
   "crates/mars-graph",
+  "crates/mars-telemetry",
   "crates/mars-sdk",
   "crates/mars-shm",
   "crates/mars-engine",
@@ -46,6 +47,9 @@ tokio = { version = "1.43", features = ["rt-multi-thread", "macros", "net", "io-
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+opentelemetry = { version = "0.31", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.31", features = ["trace", "metrics", "grpc-tonic"] }
 uuid = { version = "1.12", features = ["v4", "serde"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ cargo build
 cargo test
 ```
 
+Optional telemetry build (OTel support):
+
+```bash
+cargo build --workspace --features otel
+```
+
 Engine robustness and perf checks:
 
 ```bash
@@ -198,6 +204,8 @@ Benchmark gate policy, CI job mapping, and local reproduction commands:
 ## Getting Started
 
 See the full setup and first-run guide: `docs/getting-started.md`.
+
+Telemetry setup and metric/span reference: `docs/telemetry.md`.
 
 Quick install:
 

--- a/crates/mars-cli/Cargo.toml
+++ b/crates/mars-cli/Cargo.toml
@@ -10,6 +10,10 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = []
+otel = ["mars-telemetry/otel", "mars-ipc/otel"]
+
 [[bin]]
 name = "mars"
 path = "src/main.rs"
@@ -20,6 +24,7 @@ dirs.workspace = true
 mars-coreaudio = { path = "../mars-coreaudio" }
 mars-ipc = { path = "../mars-ipc" }
 mars-profile = { path = "../mars-profile" }
+mars-telemetry = { path = "../mars-telemetry" }
 mars-types = { path = "../mars-types" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mars-cli/src/main.rs
+++ b/crates/mars-cli/src/main.rs
@@ -4,11 +4,12 @@ use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use clap::{Parser, Subcommand};
 use mars_ipc::{DaemonRequest, DaemonResponse, IpcClient, LogRequest, LogResponse};
 use mars_profile::{TemplateKind, render_template};
+use mars_telemetry::{Attribute, ServiceIdentity, TelemetryRuntime};
 use mars_types::{
     ApplyRequest, CaptureProcessInfo, ClearRequest, DEFAULT_PROFILE_DIR_RELATIVE,
     DEFAULT_SOCKET_PATH_RELATIVE, DaemonStatus, DoctorReport, ExitCode, PlanRequest,
@@ -103,6 +104,26 @@ enum Commands {
     Doctor,
 }
 
+impl Commands {
+    #[must_use]
+    const fn telemetry_name(&self) -> &'static str {
+        match self {
+            Self::Create { .. } => "create",
+            Self::Open { .. } => "open",
+            Self::Apply { .. } => "apply",
+            Self::Clear { .. } => "clear",
+            Self::Validate { .. } => "validate",
+            Self::Plan { .. } => "plan",
+            Self::Status => "status",
+            Self::Devices => "devices",
+            Self::Processes => "processes",
+            Self::Test { .. } => "test",
+            Self::Logs { .. } => "logs",
+            Self::Doctor => "doctor",
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 enum CliError {
     #[error("{message}")]
@@ -118,11 +139,91 @@ enum CliError {
     Yaml(#[from] serde_yaml::Error),
 }
 
+#[derive(Debug, Clone)]
+struct CliTelemetry {
+    tracer: mars_telemetry::TelemetryTracer,
+    command_count: mars_telemetry::U64Counter,
+    command_duration: mars_telemetry::U64Histogram,
+}
+
+impl CliTelemetry {
+    fn new(runtime: &TelemetryRuntime) -> Self {
+        let meter = runtime.meter("mars-cli");
+        Self {
+            tracer: runtime.tracer("mars-cli"),
+            command_count: meter.u64_counter(
+                "mars.cli.command.count",
+                "Count of mars CLI commands",
+                "{command}",
+            ),
+            command_duration: meter.u64_histogram(
+                "mars.cli.command.duration",
+                "Duration of mars CLI commands",
+                "ms",
+            ),
+        }
+    }
+
+    fn record(
+        &self,
+        command_name: &'static str,
+        json_output: bool,
+        elapsed_ms: u64,
+        outcome: &Result<ExitCode, CliError>,
+        span: &mars_telemetry::SpanGuard,
+    ) {
+        let (success, exit_code, error_description) = command_outcome(outcome);
+        let attrs = [
+            Attribute::string("command", command_name),
+            Attribute::bool("success", success),
+            Attribute::i64("exit_code", i64::from(exit_code.as_i32())),
+            Attribute::bool("json_output", json_output),
+        ];
+        self.command_count.add(1, &attrs);
+        self.command_duration.record(elapsed_ms, &attrs);
+        span.set_attributes(&attrs);
+        if success {
+            span.set_status_ok();
+        } else {
+            span.set_status_error(error_description);
+        }
+    }
+}
+
+fn command_outcome(outcome: &Result<ExitCode, CliError>) -> (bool, ExitCode, String) {
+    match outcome {
+        Ok(exit_code) => (
+            *exit_code == ExitCode::Success,
+            *exit_code,
+            if *exit_code == ExitCode::Success {
+                String::new()
+            } else {
+                format!("command exited with code {}", exit_code.as_i32())
+            },
+        ),
+        Err(CliError::WithExit { message, exit_code }) => (false, *exit_code, message.clone()),
+        Err(other) => (false, ExitCode::DaemonCommunication, other.to_string()),
+    }
+}
+
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
+    let telemetry_runtime = match TelemetryRuntime::init(ServiceIdentity::new(
+        "mars-cli",
+        env!("CARGO_PKG_VERSION"),
+        "cli",
+    )) {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            eprintln!("{error}");
+            std::process::exit(ExitCode::DaemonCommunication.as_i32());
+        }
+    };
+    let telemetry = CliTelemetry::new(&telemetry_runtime);
+
     let exit_code = tokio::select! {
-        result = run(cli) => {
+        result = run(cli, &telemetry) => {
             match result {
                 Ok(code) => code,
                 Err(error) => {
@@ -137,10 +238,30 @@ async fn main() {
         }
         _ = tokio::signal::ctrl_c() => ExitCode::Interrupted,
     };
+
+    drop(telemetry_runtime);
     std::process::exit(exit_code.as_i32());
 }
 
-async fn run(cli: Cli) -> Result<ExitCode, CliError> {
+async fn run(cli: Cli, telemetry: &CliTelemetry) -> Result<ExitCode, CliError> {
+    let command_name = cli.command.telemetry_name();
+    let json_output = cli.json;
+    let mut span = telemetry.tracer.start_span(
+        "mars.cli.command",
+        &[
+            Attribute::string("command", command_name),
+            Attribute::bool("json_output", json_output),
+        ],
+    );
+    let started = Instant::now();
+    let outcome = run_inner(cli).await;
+    let elapsed_ms = started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+    telemetry.record(command_name, json_output, elapsed_ms, &outcome, &span);
+    span.end();
+    outcome
+}
+
+async fn run_inner(cli: Cli) -> Result<ExitCode, CliError> {
     match cli.command {
         Commands::Create {
             profile_name,

--- a/crates/mars-daemon/Cargo.toml
+++ b/crates/mars-daemon/Cargo.toml
@@ -10,6 +10,10 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = []
+otel = ["mars-telemetry/otel", "mars-ipc/otel", "mars-engine/otel"]
+
 [[bin]]
 name = "marsd"
 path = "src/bin/marsd.rs"
@@ -29,6 +33,7 @@ mars-hal-client = { path = "../mars-hal-client" }
 mars-ipc = { path = "../mars-ipc" }
 mars-profile = { path = "../mars-profile" }
 mars-shm = { path = "../mars-shm" }
+mars-telemetry = { path = "../mars-telemetry" }
 mars-types = { path = "../mars-types" }
 once_cell.workspace = true
 parking_lot.workspace = true

--- a/crates/mars-daemon/src/bin/marsd.rs
+++ b/crates/mars-daemon/src/bin/marsd.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use clap::Parser;
 use mars_daemon::{MarsDaemon, setup_logging};
+use mars_telemetry::{ServiceIdentity, TelemetryRuntime};
 use mars_types::DEFAULT_LOG_PATH_RELATIVE;
 #[cfg(unix)]
 use tokio::signal::unix::{SignalKind, signal};
@@ -38,6 +39,13 @@ async fn main() -> anyhow::Result<()> {
     if !args.serve {
         return Ok(());
     }
+
+    let _telemetry_runtime = TelemetryRuntime::init(ServiceIdentity::new(
+        "marsd",
+        env!("CARGO_PKG_VERSION"),
+        "daemon",
+    ))
+    .map_err(|error| anyhow::anyhow!(error.to_string()))?;
 
     let _guard = setup_logging()?;
     let daemon = Arc::new(MarsDaemon::new(default_log_path()));

--- a/crates/mars-daemon/src/lib.rs
+++ b/crates/mars-daemon/src/lib.rs
@@ -35,6 +35,7 @@ use mars_ipc::{
 };
 use mars_profile::{ValidatedProfile, load_profile, validate_only};
 use mars_shm::{RingSpec, StreamDirection, global_registry, stream_name};
+use mars_telemetry::{Attribute, F64Histogram, TelemetryTracer, U64Counter, U64Histogram};
 use mars_types::{
     ApplyPlan, ApplyRequest, ApplyResult, CaptureRuntimeHealth, CaptureRuntimeStatus, DaemonStatus,
     DeviceDescriptor, DriverStatusSummary, ExitCode, ExternalRuntimeStatus, MANAGED_UID_PREFIX,
@@ -45,6 +46,124 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use sink_runtime::{SinkBinding, SinkBindingKind, SinkRuntime, SinkRuntimeSubmitter};
 use tracing::{debug, info, warn};
+
+#[derive(Debug)]
+struct DaemonTelemetry {
+    tracer: TelemetryTracer,
+    apply_count: U64Counter,
+    apply_duration: U64Histogram,
+    apply_stage_duration: U64Histogram,
+    apply_rollback_count: U64Counter,
+    render_cycle_duration: U64Histogram,
+    render_budget_utilization: F64Histogram,
+    render_deadline_miss_count: U64Counter,
+    render_xrun_count: U64Counter,
+    external_underrun_count: U64Counter,
+    external_overrun_count: U64Counter,
+    sink_drop_count: U64Counter,
+    sink_write_error_count: U64Counter,
+    capture_active_taps: U64Histogram,
+    capture_failed_taps: U64Counter,
+    plugin_timeout_count: U64Counter,
+    plugin_error_count: U64Counter,
+    plugin_restart_count: U64Counter,
+}
+
+static DAEMON_TELEMETRY: OnceLock<DaemonTelemetry> = OnceLock::new();
+
+fn daemon_telemetry() -> &'static DaemonTelemetry {
+    DAEMON_TELEMETRY.get_or_init(|| {
+        let meter = mars_telemetry::global_meter("mars-daemon");
+        DaemonTelemetry {
+            tracer: mars_telemetry::global_tracer("mars-daemon"),
+            apply_count: meter.u64_counter(
+                "mars.apply.count",
+                "Count of apply requests",
+                "{apply}",
+            ),
+            apply_duration: meter.u64_histogram(
+                "mars.apply.duration",
+                "Apply transaction duration",
+                "ms",
+            ),
+            apply_stage_duration: meter.u64_histogram(
+                "mars.apply.stage.duration",
+                "Apply stage duration",
+                "ms",
+            ),
+            apply_rollback_count: meter.u64_counter(
+                "mars.apply.rollback.count",
+                "Count of apply rollbacks",
+                "{rollback}",
+            ),
+            render_cycle_duration: meter.u64_histogram(
+                "mars.render.cycle.duration",
+                "Render cycle duration sampled from runtime",
+                "ns",
+            ),
+            render_budget_utilization: meter.f64_histogram(
+                "mars.render.cycle.budget_utilization",
+                "Render cycle budget utilization ratio",
+                "ratio",
+            ),
+            render_deadline_miss_count: meter.u64_counter(
+                "mars.render.deadline_miss.count",
+                "Render deadline miss count",
+                "{miss}",
+            ),
+            render_xrun_count: meter.u64_counter(
+                "mars.render.xrun.count",
+                "Render xrun count",
+                "{xrun}",
+            ),
+            external_underrun_count: meter.u64_counter(
+                "mars.external.underrun.count",
+                "External runtime underrun count",
+                "{underrun}",
+            ),
+            external_overrun_count: meter.u64_counter(
+                "mars.external.overrun.count",
+                "External runtime overrun count",
+                "{overrun}",
+            ),
+            sink_drop_count: meter.u64_counter(
+                "mars.sink.drop.count",
+                "Sink dropped batch count",
+                "{drop}",
+            ),
+            sink_write_error_count: meter.u64_counter(
+                "mars.sink.write_error.count",
+                "Sink write error count",
+                "{error}",
+            ),
+            capture_active_taps: meter.u64_histogram(
+                "mars.capture.tap.active",
+                "Active capture taps sampled from runtime",
+                "{tap}",
+            ),
+            capture_failed_taps: meter.u64_counter(
+                "mars.capture.tap.failed",
+                "Failed capture tap count",
+                "{failed_tap}",
+            ),
+            plugin_timeout_count: meter.u64_counter(
+                "mars.plugin.timeout.count",
+                "Plugin timeout count",
+                "{timeout}",
+            ),
+            plugin_error_count: meter.u64_counter(
+                "mars.plugin.error.count",
+                "Plugin error count",
+                "{error}",
+            ),
+            plugin_restart_count: meter.u64_counter(
+                "mars.plugin.restart.count",
+                "Plugin restart count",
+                "{restart}",
+            ),
+        }
+    })
+}
 
 #[derive(Debug)]
 pub struct MarsDaemon {
@@ -251,6 +370,82 @@ impl RenderRuntime {
     }
 }
 
+#[derive(Debug)]
+struct ApplyStageGuard<'a> {
+    telemetry: &'a DaemonTelemetry,
+    span: mars_telemetry::SpanGuard,
+    stage: &'static str,
+    started: Instant,
+    success: bool,
+    failed_stage: &'a mut Option<&'static str>,
+}
+
+impl<'a> ApplyStageGuard<'a> {
+    fn new(
+        telemetry: &'a DaemonTelemetry,
+        parent_span: &mars_telemetry::SpanGuard,
+        stage: &'static str,
+        span_name: &'static str,
+        failed_stage: &'a mut Option<&'static str>,
+    ) -> Self {
+        let span = telemetry.tracer.start_child_span(
+            parent_span,
+            span_name,
+            &[Attribute::string("stage", stage)],
+        );
+        Self {
+            telemetry,
+            span,
+            stage,
+            started: Instant::now(),
+            success: false,
+            failed_stage,
+        }
+    }
+
+    fn success(&mut self) {
+        self.success = true;
+    }
+}
+
+impl Drop for ApplyStageGuard<'_> {
+    fn drop(&mut self) {
+        let elapsed_ms = self.started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+        let attrs = [
+            Attribute::string("stage", self.stage),
+            Attribute::bool("success", self.success),
+        ];
+        self.telemetry
+            .apply_stage_duration
+            .record(elapsed_ms, &attrs);
+        self.span.set_attributes(&attrs);
+        if self.success {
+            self.span.set_status_ok();
+        } else {
+            if self.failed_stage.is_none() {
+                *self.failed_stage = Some(self.stage);
+            }
+            self.span
+                .set_status_error(format!("apply stage '{}' failed", self.stage));
+        }
+        self.span.end();
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct RuntimeTelemetryCheckpoint {
+    deadline_miss_count: u64,
+    xrun_count: u64,
+    underrun_count: u64,
+    overrun_count: u64,
+    sink_drop_count: u64,
+    sink_write_error_count: u64,
+    capture_failed_taps: u64,
+    plugin_timeout_count: u64,
+    plugin_error_count: u64,
+    plugin_restart_count: u64,
+}
+
 fn update_max_atomic(cell: &AtomicU64, value: u64) {
     let mut current = cell.load(Ordering::Relaxed);
     while value > current {
@@ -259,6 +454,12 @@ fn update_max_atomic(cell: &AtomicU64, value: u64) {
             Err(actual) => current = actual,
         }
     }
+}
+
+fn counter_delta(current: u64, previous: &mut u64) -> u64 {
+    let delta = current.saturating_sub(*previous);
+    *previous = current;
+    delta
 }
 
 fn run_render_loop(
@@ -470,7 +671,159 @@ impl MarsDaemon {
     }
 
     pub async fn run(self: Arc<Self>, socket_path: &Path) -> Result<(), mars_ipc::IpcError> {
-        serve(socket_path, self).await
+        let reporter = self.start_runtime_telemetry_reporter();
+        let result = serve(socket_path, self).await;
+        if let Some((stop, handle)) = reporter {
+            stop.store(true, Ordering::Relaxed);
+            let _ = handle.join();
+        }
+        result
+    }
+
+    fn start_runtime_telemetry_reporter(
+        self: &Arc<Self>,
+    ) -> Option<(Arc<AtomicBool>, JoinHandle<()>)> {
+        if !mars_telemetry::telemetry_enabled() {
+            return None;
+        }
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let daemon = Arc::clone(self);
+        let thread_stop = Arc::clone(&stop);
+        let handle = std::thread::Builder::new()
+            .name("marsd-telemetry".to_string())
+            .spawn(move || {
+                let telemetry = daemon_telemetry();
+                let mut checkpoint = RuntimeTelemetryCheckpoint::default();
+                while !thread_stop.load(Ordering::Relaxed) {
+                    daemon.runtime_telemetry_tick(telemetry, &mut checkpoint);
+                    std::thread::sleep(Duration::from_secs(1));
+                }
+            })
+            .ok()?;
+
+        Some((stop, handle))
+    }
+
+    fn runtime_telemetry_tick(
+        &self,
+        telemetry: &DaemonTelemetry,
+        checkpoint: &mut RuntimeTelemetryCheckpoint,
+    ) {
+        let status = self.status_internal();
+        let sample_rate = status.sample_rate.max(1);
+        let buffer_frames = status.buffer_frames.max(1);
+        let attrs = [
+            Attribute::u64("sample_rate", u64::from(sample_rate)),
+            Attribute::u64("buffer_frames", u64::from(buffer_frames)),
+        ];
+
+        telemetry
+            .render_cycle_duration
+            .record(status.counters.last_cycle_ns, &attrs);
+
+        let budget_ns = (1_000_000_000_f64 * f64::from(buffer_frames)) / f64::from(sample_rate);
+        if budget_ns.is_finite() && budget_ns > 0.0 {
+            telemetry
+                .render_budget_utilization
+                .record(status.counters.last_cycle_ns as f64 / budget_ns, &attrs);
+        }
+
+        let deadline_delta = counter_delta(
+            status.counters.deadline_miss_count,
+            &mut checkpoint.deadline_miss_count,
+        );
+        if deadline_delta > 0 {
+            telemetry
+                .render_deadline_miss_count
+                .add(deadline_delta, &attrs);
+        }
+
+        let xrun_delta = counter_delta(status.counters.xrun_count, &mut checkpoint.xrun_count);
+        if xrun_delta > 0 {
+            telemetry
+                .render_xrun_count
+                .add(xrun_delta, &[Attribute::string("source", "runtime")]);
+        }
+
+        let underrun_delta = counter_delta(
+            status.counters.underrun_count,
+            &mut checkpoint.underrun_count,
+        );
+        if underrun_delta > 0 {
+            telemetry
+                .external_underrun_count
+                .add(underrun_delta, &attrs);
+        }
+
+        let overrun_delta =
+            counter_delta(status.counters.overrun_count, &mut checkpoint.overrun_count);
+        if overrun_delta > 0 {
+            telemetry.external_overrun_count.add(overrun_delta, &attrs);
+        }
+
+        let sink_drop_delta = counter_delta(
+            status.sink_runtime.dropped_batches,
+            &mut checkpoint.sink_drop_count,
+        );
+        if sink_drop_delta > 0 {
+            telemetry
+                .sink_drop_count
+                .add(sink_drop_delta, &[Attribute::string("sink_kind", "all")]);
+        }
+
+        let sink_write_error_delta = counter_delta(
+            status.sink_runtime.write_errors,
+            &mut checkpoint.sink_write_error_count,
+        );
+        if sink_write_error_delta > 0 {
+            telemetry.sink_write_error_count.add(
+                sink_write_error_delta,
+                &[Attribute::string("sink_kind", "all")],
+            );
+        }
+
+        telemetry.capture_active_taps.record(
+            status.capture_runtime.active_taps as u64,
+            &[Attribute::string("kind", "all")],
+        );
+        let capture_failed_delta = counter_delta(
+            status.capture_runtime.failed_taps as u64,
+            &mut checkpoint.capture_failed_taps,
+        );
+        if capture_failed_delta > 0 {
+            telemetry
+                .capture_failed_taps
+                .add(capture_failed_delta, &[Attribute::string("kind", "all")]);
+        }
+
+        let plugin_timeout_delta = counter_delta(
+            status.plugin_runtime.timeout_count,
+            &mut checkpoint.plugin_timeout_count,
+        );
+        if plugin_timeout_delta > 0 {
+            telemetry
+                .plugin_timeout_count
+                .add(plugin_timeout_delta, &[Attribute::string("api", "all")]);
+        }
+        let plugin_error_delta = counter_delta(
+            status.plugin_runtime.error_count,
+            &mut checkpoint.plugin_error_count,
+        );
+        if plugin_error_delta > 0 {
+            telemetry
+                .plugin_error_count
+                .add(plugin_error_delta, &[Attribute::string("api", "all")]);
+        }
+        let plugin_restart_delta = counter_delta(
+            status.plugin_runtime.restart_count,
+            &mut checkpoint.plugin_restart_count,
+        );
+        if plugin_restart_delta > 0 {
+            telemetry
+                .plugin_restart_count
+                .add(plugin_restart_delta, &[Attribute::string("api", "all")]);
+        }
     }
 
     fn stop_render_runtime(&self) {
@@ -647,262 +1000,414 @@ impl MarsDaemon {
     }
 
     fn apply_internal(&self, request: ApplyRequest) -> Result<ApplyResult, ApiError> {
-        let deadline = Self::apply_deadline(request.timeout_ms);
-        Self::ensure_within_deadline(deadline, "profile-validate")?;
+        let telemetry = daemon_telemetry();
+        let started = Instant::now();
+        let mut failed_stage = None::<&'static str>;
+        let mut rollback_triggered = false;
+        let mut apply_span = telemetry.tracer.start_span(
+            "mars.apply.transaction",
+            &[
+                Attribute::bool("dry_run", request.dry_run),
+                Attribute::bool("no_delete", request.no_delete),
+                Attribute::u64("timeout_ms", request.timeout_ms),
+            ],
+        );
 
-        let validated = load_profile(Path::new(&request.profile_path)).map_err(|error| {
-            ApiError::new(
-                format!(
-                    "profile validation failed (strict policy requires apply_mode=atomic and on_missing_external=error): {error}"
-                ),
-                ExitCode::InvalidInput,
-            )
-        })?;
+        let outcome = (|| {
+            let deadline = Self::apply_deadline(request.timeout_ms);
+            let validated = {
+                let mut stage = ApplyStageGuard::new(
+                    telemetry,
+                    &apply_span,
+                    "profile_validate",
+                    "mars.apply.stage.profile_validate",
+                    &mut failed_stage,
+                );
+                Self::ensure_within_deadline(deadline, "profile-validate")?;
+                let validated = load_profile(Path::new(&request.profile_path)).map_err(|error| {
+                    ApiError::new(
+                        format!(
+                            "profile validation failed (strict policy requires apply_mode=atomic and on_missing_external=error): {error}"
+                        ),
+                        ExitCode::InvalidInput,
+                    )
+                })?;
+                stage.success();
+                validated
+            };
 
-        let plan_request = PlanRequest {
-            profile_path: request.profile_path.clone(),
-            no_delete: request.no_delete,
-        };
+            let plan_request = PlanRequest {
+                profile_path: request.profile_path.clone(),
+                no_delete: request.no_delete,
+            };
+            let plan = {
+                let mut stage = ApplyStageGuard::new(
+                    telemetry,
+                    &apply_span,
+                    "plan",
+                    "mars.apply.stage.plan",
+                    &mut failed_stage,
+                );
+                Self::ensure_within_deadline(deadline, "plan")?;
+                let plan = self.plan_internal(&plan_request, &validated)?;
+                stage.success();
+                plan
+            };
 
-        Self::ensure_within_deadline(deadline, "plan")?;
-        let plan = self.plan_internal(&plan_request, &validated)?;
-        if request.dry_run {
-            return Ok(ApplyResult {
-                applied: false,
-                warnings: plan.warnings.clone(),
-                plan,
-                errors: Vec::new(),
-            });
-        }
+            if request.dry_run {
+                return Ok(ApplyResult {
+                    applied: false,
+                    warnings: plan.warnings.clone(),
+                    plan,
+                    errors: Vec::new(),
+                });
+            }
 
-        Self::ensure_within_deadline(deadline, "external-resolve")?;
-        let inventory = list_device_inventory().map_err(coreaudio_to_api_error)?;
-        let resolution = resolve_externals(&validated.profile, &inventory);
-        if !resolution.errors.is_empty() {
-            return Err(ApiError::new(
-                format!("missing external devices: {}", resolution.errors.join("; ")),
-                ExitCode::MissingExternal,
-            ));
-        }
-
-        let previous_state = self.state.lock().clone();
-        let driver_snapshot_path = driver_state_path()
-            .map_err(|error| ApiError::new(error, ExitCode::DriverUnavailable))?;
-        let driver_snapshot = capture_driver_state_snapshot(&driver_snapshot_path)
-            .map_err(|error| ApiError::new(error, ExitCode::DriverUnavailable))?;
-
-        // When --no-delete is set, merge devices from the previous profile that
-        // would otherwise be removed so the HAL desired state retains them.
-        let effective_profile = if request.no_delete {
-            if let Some(prev) = previous_state.current_profile.clone() {
-                let next_output_ids: BTreeSet<&str> = validated
-                    .profile
-                    .virtual_devices
-                    .outputs
-                    .iter()
-                    .map(|d| d.id.as_str())
-                    .collect();
-                let next_input_ids: BTreeSet<&str> = validated
-                    .profile
-                    .virtual_devices
-                    .inputs
-                    .iter()
-                    .map(|d| d.id.as_str())
-                    .collect();
-
-                let mut merged = validated.profile.clone();
-                for output in &prev.virtual_devices.outputs {
-                    if !next_output_ids.contains(output.id.as_str()) {
-                        merged.virtual_devices.outputs.push(output.clone());
-                    }
+            let resolution = {
+                let mut stage = ApplyStageGuard::new(
+                    telemetry,
+                    &apply_span,
+                    "external_resolve",
+                    "mars.apply.stage.external_resolve",
+                    &mut failed_stage,
+                );
+                Self::ensure_within_deadline(deadline, "external-resolve")?;
+                let inventory = list_device_inventory().map_err(coreaudio_to_api_error)?;
+                let resolution = resolve_externals(&validated.profile, &inventory);
+                if !resolution.errors.is_empty() {
+                    return Err(ApiError::new(
+                        format!("missing external devices: {}", resolution.errors.join("; ")),
+                        ExitCode::MissingExternal,
+                    ));
                 }
-                for input in &prev.virtual_devices.inputs {
-                    if !next_input_ids.contains(input.id.as_str()) {
-                        merged.virtual_devices.inputs.push(input.clone());
+                stage.success();
+                resolution
+            };
+
+            let previous_state = self.state.lock().clone();
+            let driver_snapshot_path = driver_state_path()
+                .map_err(|error| ApiError::new(error, ExitCode::DriverUnavailable))?;
+            let driver_snapshot = capture_driver_state_snapshot(&driver_snapshot_path)
+                .map_err(|error| ApiError::new(error, ExitCode::DriverUnavailable))?;
+
+            // When --no-delete is set, merge devices from the previous profile that
+            // would otherwise be removed so the HAL desired state retains them.
+            let effective_profile = if request.no_delete {
+                if let Some(prev) = previous_state.current_profile.clone() {
+                    let next_output_ids: BTreeSet<&str> = validated
+                        .profile
+                        .virtual_devices
+                        .outputs
+                        .iter()
+                        .map(|d| d.id.as_str())
+                        .collect();
+                    let next_input_ids: BTreeSet<&str> = validated
+                        .profile
+                        .virtual_devices
+                        .inputs
+                        .iter()
+                        .map(|d| d.id.as_str())
+                        .collect();
+
+                    let mut merged = validated.profile.clone();
+                    for output in &prev.virtual_devices.outputs {
+                        if !next_output_ids.contains(output.id.as_str()) {
+                            merged.virtual_devices.outputs.push(output.clone());
+                        }
                     }
+                    for input in &prev.virtual_devices.inputs {
+                        if !next_input_ids.contains(input.id.as_str()) {
+                            merged.virtual_devices.inputs.push(input.clone());
+                        }
+                    }
+                    merged
+                } else {
+                    validated.profile.clone()
                 }
-                merged
             } else {
                 validated.profile.clone()
+            };
+
+            let sample_rate = effective_profile
+                .audio
+                .sample_rate
+                .as_value()
+                .unwrap_or(48_000);
+            let channels = effective_profile.audio.channels.as_value().unwrap_or(2);
+            let mut warnings = plan.warnings.clone();
+            if driver_stub_active() {
+                warnings.push(
+                    "mars.driver is not loaded by coreaudiod; apply completed in stub mode (virtual devices will not appear in system audio list)".to_string(),
+                );
             }
-        } else {
-            validated.profile.clone()
-        };
 
-        let sample_rate = effective_profile
-            .audio
-            .sample_rate
-            .as_value()
-            .unwrap_or(48_000);
-        let channels = effective_profile.audio.channels.as_value().unwrap_or(2);
-        let mut warnings = plan.warnings.clone();
-        if driver_stub_active() {
-            warnings.push(
-                "mars.driver is not loaded by coreaudiod; apply completed in stub mode (virtual devices will not appear in system audio list)".to_string(),
-            );
-        }
-        Self::ensure_within_deadline(deadline, "driver-compatibility")?;
-        if let Err(error) = ensure_driver_compatibility_for_apply() {
-            return Err(ApiError::new(error, ExitCode::DriverUnavailable));
-        }
-
-        let devices = collect_devices(&effective_profile, &resolution.resolved);
-
-        self.stop_render_runtime();
-        self.stop_capture_runtime();
-
-        Self::ensure_within_deadline(deadline, "driver-stage").map_err(|timeout_error| {
-            self.rollback_apply(
-                previous_state.clone(),
-                &driver_snapshot,
-                timeout_error.message,
-                ExitCode::ApplyFailed,
-            )
-        })?;
-        if let Err(error) =
-            stage_driver_state(&effective_profile, &validated.graph, sample_rate, channels)
-        {
-            warn!(error = %error, "failed to stage driver state");
-            return Err(self.rollback_apply(
-                previous_state,
-                &driver_snapshot,
-                error,
-                ExitCode::DriverUnavailable,
-            ));
-        }
-        Self::ensure_within_deadline(deadline, "graph-activate").map_err(|timeout_error| {
-            self.rollback_apply(
-                previous_state.clone(),
-                &driver_snapshot,
-                timeout_error.message,
-                ExitCode::ApplyFailed,
-            )
-        })?;
-
-        let mut state = self.state.lock();
-        let engine = if let (Some(previous_profile), Some(existing_engine)) =
-            (state.current_profile.as_ref(), state.engine.as_ref())
-        {
-            if render_restart_required(previous_profile, &effective_profile) {
-                Arc::new(Engine::new(EngineSnapshot {
-                    graph: validated.graph.clone(),
-                    sample_rate,
-                    buffer_frames: effective_profile.audio.buffer_frames,
-                }))
-            } else {
-                existing_engine.swap_snapshot(EngineSnapshot {
-                    graph: validated.graph.clone(),
-                    sample_rate,
-                    buffer_frames: effective_profile.audio.buffer_frames,
-                });
-                existing_engine.clone()
+            {
+                let mut stage = ApplyStageGuard::new(
+                    telemetry,
+                    &apply_span,
+                    "driver_compatibility",
+                    "mars.apply.stage.driver_compatibility",
+                    &mut failed_stage,
+                );
+                Self::ensure_within_deadline(deadline, "driver-compatibility")?;
+                if let Err(error) = ensure_driver_compatibility_for_apply() {
+                    return Err(ApiError::new(error, ExitCode::DriverUnavailable));
+                }
+                stage.success();
             }
-        } else {
-            Arc::new(Engine::new(EngineSnapshot {
-                graph: validated.graph.clone(),
-                sample_rate,
-                buffer_frames: effective_profile.audio.buffer_frames,
-            }))
-        };
 
-        state.current_profile_path = Some(request.profile_path);
-        state.current_profile = Some(effective_profile);
-        state.graph = Some(validated.graph.clone());
-        state.engine = Some(engine);
-        state.devices = devices;
-        state.external_runtime = ExternalRuntimeStatus::default();
-        state.capture_runtime = CaptureRuntimeStatus::default();
-        state.sink_runtime = SinkRuntimeStatus::default();
-        state.plugin_runtime = PluginHostRuntimeStatus::default();
-        drop(state);
+            let devices = collect_devices(&effective_profile, &resolution.resolved);
 
-        if let Err(error) = self.sync_capture_runtime() {
-            return Err(self.rollback_apply(
-                previous_state.clone(),
-                &driver_snapshot,
-                error,
-                ExitCode::ApplyFailed,
-            ));
-        }
+            self.stop_render_runtime();
+            self.stop_capture_runtime();
 
-        if let Err(error) = self.sync_render_runtime() {
-            return Err(self.rollback_apply(
-                previous_state.clone(),
-                &driver_snapshot,
-                error,
-                ExitCode::ApplyFailed,
-            ));
-        }
-
-        Self::ensure_within_deadline(deadline, "runtime-ready").map_err(|timeout_error| {
-            self.rollback_apply(
-                previous_state.clone(),
-                &driver_snapshot,
-                timeout_error.message,
-                ExitCode::ApplyFailed,
-            )
-        })?;
-
-        {
-            let runtime_guard = self.render_runtime.lock();
-            if let Some(runtime) = runtime_guard.as_ref() {
-                if let Some(external_runtime) = runtime.external_runtime.as_ref() {
-                    let snapshot = external_runtime.snapshot();
-                    let expected_inputs = runtime.config.external_inputs.len();
-                    let expected_outputs = runtime.config.external_outputs.len();
-                    if snapshot.status.connected_inputs != expected_inputs
-                        || snapshot.status.connected_outputs != expected_outputs
-                    {
-                        return Err(self.rollback_apply(
+            {
+                let mut stage = ApplyStageGuard::new(
+                    telemetry,
+                    &apply_span,
+                    "driver_stage",
+                    "mars.apply.stage.driver_stage",
+                    &mut failed_stage,
+                );
+                Self::ensure_within_deadline(deadline, "driver-stage").map_err(
+                    |timeout_error| {
+                        rollback_triggered = true;
+                        self.rollback_apply(
                             previous_state.clone(),
                             &driver_snapshot,
-                            format!(
-                                "external runtime readiness failed: expected inputs={} outputs={}, got inputs={} outputs={}",
-                                expected_inputs,
-                                expected_outputs,
-                                snapshot.status.connected_inputs,
-                                snapshot.status.connected_outputs
-                            ),
+                            timeout_error.message,
                             ExitCode::ApplyFailed,
-                        ));
+                        )
+                    },
+                )?;
+                if let Err(error) =
+                    stage_driver_state(&effective_profile, &validated.graph, sample_rate, channels)
+                {
+                    rollback_triggered = true;
+                    warn!(error = %error, "failed to stage driver state");
+                    return Err(self.rollback_apply(
+                        previous_state.clone(),
+                        &driver_snapshot,
+                        error,
+                        ExitCode::DriverUnavailable,
+                    ));
+                }
+                stage.success();
+            }
+
+            {
+                let mut stage = ApplyStageGuard::new(
+                    telemetry,
+                    &apply_span,
+                    "graph_activate",
+                    "mars.apply.stage.graph_activate",
+                    &mut failed_stage,
+                );
+                Self::ensure_within_deadline(deadline, "graph-activate").map_err(
+                    |timeout_error| {
+                        rollback_triggered = true;
+                        self.rollback_apply(
+                            previous_state.clone(),
+                            &driver_snapshot,
+                            timeout_error.message,
+                            ExitCode::ApplyFailed,
+                        )
+                    },
+                )?;
+
+                let mut state = self.state.lock();
+                let engine = if let (Some(previous_profile), Some(existing_engine)) =
+                    (state.current_profile.as_ref(), state.engine.as_ref())
+                {
+                    if render_restart_required(previous_profile, &effective_profile) {
+                        Arc::new(Engine::new(EngineSnapshot {
+                            graph: validated.graph.clone(),
+                            sample_rate,
+                            buffer_frames: effective_profile.audio.buffer_frames,
+                        }))
+                    } else {
+                        existing_engine.swap_snapshot(EngineSnapshot {
+                            graph: validated.graph.clone(),
+                            sample_rate,
+                            buffer_frames: effective_profile.audio.buffer_frames,
+                        });
+                        existing_engine.clone()
+                    }
+                } else {
+                    Arc::new(Engine::new(EngineSnapshot {
+                        graph: validated.graph.clone(),
+                        sample_rate,
+                        buffer_frames: effective_profile.audio.buffer_frames,
+                    }))
+                };
+
+                state.current_profile_path = Some(request.profile_path.clone());
+                state.current_profile = Some(effective_profile);
+                state.graph = Some(validated.graph.clone());
+                state.engine = Some(engine);
+                state.devices = devices;
+                state.external_runtime = ExternalRuntimeStatus::default();
+                state.capture_runtime = CaptureRuntimeStatus::default();
+                state.sink_runtime = SinkRuntimeStatus::default();
+                state.plugin_runtime = PluginHostRuntimeStatus::default();
+                drop(state);
+                stage.success();
+            }
+
+            {
+                let mut stage = ApplyStageGuard::new(
+                    telemetry,
+                    &apply_span,
+                    "capture_sync",
+                    "mars.apply.stage.capture_sync",
+                    &mut failed_stage,
+                );
+                if let Err(error) = self.sync_capture_runtime() {
+                    rollback_triggered = true;
+                    return Err(self.rollback_apply(
+                        previous_state.clone(),
+                        &driver_snapshot,
+                        error,
+                        ExitCode::ApplyFailed,
+                    ));
+                }
+                stage.success();
+            }
+
+            {
+                let mut stage = ApplyStageGuard::new(
+                    telemetry,
+                    &apply_span,
+                    "render_sync",
+                    "mars.apply.stage.render_sync",
+                    &mut failed_stage,
+                );
+                if let Err(error) = self.sync_render_runtime() {
+                    rollback_triggered = true;
+                    return Err(self.rollback_apply(
+                        previous_state.clone(),
+                        &driver_snapshot,
+                        error,
+                        ExitCode::ApplyFailed,
+                    ));
+                }
+                stage.success();
+            }
+
+            {
+                let mut stage = ApplyStageGuard::new(
+                    telemetry,
+                    &apply_span,
+                    "runtime_ready",
+                    "mars.apply.stage.runtime_ready",
+                    &mut failed_stage,
+                );
+                Self::ensure_within_deadline(deadline, "runtime-ready").map_err(
+                    |timeout_error| {
+                        rollback_triggered = true;
+                        self.rollback_apply(
+                            previous_state.clone(),
+                            &driver_snapshot,
+                            timeout_error.message,
+                            ExitCode::ApplyFailed,
+                        )
+                    },
+                )?;
+
+                {
+                    let runtime_guard = self.render_runtime.lock();
+                    if let Some(runtime) = runtime_guard.as_ref() {
+                        if let Some(external_runtime) = runtime.external_runtime.as_ref() {
+                            let snapshot = external_runtime.snapshot();
+                            let expected_inputs = runtime.config.external_inputs.len();
+                            let expected_outputs = runtime.config.external_outputs.len();
+                            if snapshot.status.connected_inputs != expected_inputs
+                                || snapshot.status.connected_outputs != expected_outputs
+                            {
+                                rollback_triggered = true;
+                                return Err(self.rollback_apply(
+                                    previous_state.clone(),
+                                    &driver_snapshot,
+                                    format!(
+                                        "external runtime readiness failed: expected inputs={} outputs={}, got inputs={} outputs={}",
+                                        expected_inputs,
+                                        expected_outputs,
+                                        snapshot.status.connected_inputs,
+                                        snapshot.status.connected_outputs
+                                    ),
+                                    ExitCode::ApplyFailed,
+                                ));
+                            }
+                        }
                     }
                 }
+
+                if let Some(external_status) = self
+                    .render_runtime
+                    .lock()
+                    .as_ref()
+                    .map(|runtime| runtime.metrics.external_runtime.lock().clone())
+                {
+                    self.state.lock().external_runtime = external_status;
+                }
+                if let Some(sink_status) = self
+                    .render_runtime
+                    .lock()
+                    .as_ref()
+                    .and_then(|runtime| runtime.sink_runtime.as_ref().map(SinkRuntime::status))
+                {
+                    self.state.lock().sink_runtime = sink_status;
+                }
+                if let Some(capture_status) = self
+                    .capture_runtime
+                    .lock()
+                    .as_ref()
+                    .map(CaptureRuntime::status)
+                {
+                    self.state.lock().capture_runtime = capture_status;
+                }
+                stage.success();
             }
-        }
 
-        if let Some(external_status) = self
-            .render_runtime
-            .lock()
-            .as_ref()
-            .map(|runtime| runtime.metrics.external_runtime.lock().clone())
-        {
-            self.state.lock().external_runtime = external_status;
-        }
-        if let Some(sink_status) = self
-            .render_runtime
-            .lock()
-            .as_ref()
-            .and_then(|runtime| runtime.sink_runtime.as_ref().map(SinkRuntime::status))
-        {
-            self.state.lock().sink_runtime = sink_status;
-        }
-        if let Some(capture_status) = self
-            .capture_runtime
-            .lock()
-            .as_ref()
-            .map(CaptureRuntime::status)
-        {
-            self.state.lock().capture_runtime = capture_status;
-        }
+            info!("apply transaction committed");
 
-        info!("apply transaction committed");
+            Ok(ApplyResult {
+                applied: true,
+                plan,
+                warnings,
+                errors: Vec::new(),
+            })
+        })();
 
-        Ok(ApplyResult {
-            applied: true,
-            plan,
-            warnings,
-            errors: Vec::new(),
-        })
+        let elapsed_ms = started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+        let attrs = [
+            Attribute::bool("dry_run", request.dry_run),
+            Attribute::bool("no_delete", request.no_delete),
+            Attribute::bool("success", outcome.is_ok()),
+            Attribute::bool("rollback", rollback_triggered),
+        ];
+        telemetry.apply_count.add(1, &attrs);
+        telemetry.apply_duration.record(elapsed_ms, &attrs);
+        apply_span.set_attributes(&attrs);
+        if let Some(stage) = failed_stage {
+            apply_span.set_attributes(&[Attribute::string("error_stage", stage)]);
+        }
+        if rollback_triggered {
+            telemetry.apply_rollback_count.add(
+                1,
+                &[Attribute::string(
+                    "stage",
+                    failed_stage.unwrap_or("unknown"),
+                )],
+            );
+            apply_span.set_attributes(&[Attribute::bool("rollback", true)]);
+        }
+        match &outcome {
+            Ok(_) => apply_span.set_status_ok(),
+            Err(error) => apply_span.set_status_error(error.message.clone()),
+        }
+        apply_span.end();
+        outcome
     }
 
     fn clear_internal(&self, keep_devices: bool) -> Result<ApplyResult, ApiError> {

--- a/crates/mars-engine/Cargo.toml
+++ b/crates/mars-engine/Cargo.toml
@@ -10,9 +10,14 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = []
+otel = ["mars-telemetry/otel"]
+
 [dependencies]
 arc-swap.workspace = true
 mars-graph = { path = "../mars-graph" }
+mars-telemetry = { path = "../mars-telemetry" }
 mars-types = { path = "../mars-types" }
 parking_lot.workspace = true
 serde.workspace = true

--- a/crates/mars-engine/src/au_host.rs
+++ b/crates/mars-engine/src/au_host.rs
@@ -8,15 +8,17 @@ use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::sync::mpsc::{
     Receiver, RecvTimeoutError, SyncSender, TryRecvError, TrySendError, channel, sync_channel,
 };
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use mars_telemetry::{Attribute, U64Counter, U64Histogram};
 use mars_types::{
-    AuPluginConfig, PLUGIN_HOST_PROTOCOL_VERSION, PluginHostHealth, PluginHostInstanceStatus,
-    PluginHostRequest, PluginHostResponse,
+    AuPluginApi, AuPluginConfig, PLUGIN_HOST_PROTOCOL_VERSION, PluginHostHealth,
+    PluginHostInstanceStatus, PluginHostRequest, PluginHostResponse,
 };
 use parking_lot::Mutex;
 
@@ -25,6 +27,51 @@ const RESULT_QUEUE_CAPACITY: usize = 1;
 const WORKER_POLL_INTERVAL_MS: u64 = 5;
 const HOST_STARTUP_TIMEOUT_MS: u64 = 2_000;
 const HOST_CONNECT_RETRY_MS: u64 = 20;
+
+#[derive(Debug)]
+struct AuHostTelemetry {
+    process_duration: U64Histogram,
+    timeout_count: U64Counter,
+    error_count: U64Counter,
+    restart_count: U64Counter,
+}
+
+static AU_HOST_TELEMETRY: OnceLock<AuHostTelemetry> = OnceLock::new();
+
+fn au_host_telemetry() -> &'static AuHostTelemetry {
+    AU_HOST_TELEMETRY.get_or_init(|| {
+        let meter = mars_telemetry::global_meter("mars-engine");
+        AuHostTelemetry {
+            process_duration: meter.u64_histogram(
+                "mars.plugin.process.duration",
+                "Plugin host process call duration",
+                "ms",
+            ),
+            timeout_count: meter.u64_counter(
+                "mars.plugin.timeout.count",
+                "Plugin host timeout count",
+                "{timeout}",
+            ),
+            error_count: meter.u64_counter(
+                "mars.plugin.error.count",
+                "Plugin host error count",
+                "{error}",
+            ),
+            restart_count: meter.u64_counter(
+                "mars.plugin.restart.count",
+                "Plugin host restart count",
+                "{restart}",
+            ),
+        }
+    })
+}
+
+const fn au_api_label(api: AuPluginApi) -> &'static str {
+    match api {
+        AuPluginApi::Auv2 => "auv2",
+        AuPluginApi::Auv3 => "auv3",
+    }
+}
 
 #[derive(Debug)]
 pub struct AuWorker {
@@ -179,6 +226,9 @@ fn run_worker(
     stop_rx: std::sync::mpsc::Receiver<()>,
     status: Arc<Mutex<PluginHostInstanceStatus>>,
 ) {
+    let telemetry = au_host_telemetry();
+    let api_label = au_api_label(settings.config.api);
+
     let mut session = match HostSession::start(&settings) {
         Ok(session) => {
             {
@@ -197,6 +247,9 @@ fn run_worker(
             lock.health = PluginHostHealth::Failed;
             lock.error_count = lock.error_count.saturating_add(1);
             lock.last_error = Some(error.message());
+            telemetry
+                .error_count
+                .add(1, &[Attribute::string("api", api_label)]);
             None
         }
     };
@@ -235,6 +288,9 @@ fn run_worker(
                     lock.loaded = false;
                     lock.host_pid = None;
                     lock.last_error = Some(error.message());
+                    telemetry
+                        .error_count
+                        .add(1, &[Attribute::string("api", api_label)]);
                     let _ = result_tx.try_send(request.samples);
                     continue;
                 }
@@ -243,8 +299,20 @@ fn run_worker(
 
         let mut failed = None;
         if let Some(current) = session.as_mut() {
+            let process_started = Instant::now();
             match current.process(request.frames, request.channels, request.samples.clone()) {
                 Ok(samples) => {
+                    let elapsed_ms = process_started
+                        .elapsed()
+                        .as_millis()
+                        .min(u128::from(u64::MAX)) as u64;
+                    telemetry.process_duration.record(
+                        elapsed_ms,
+                        &[
+                            Attribute::string("api", api_label),
+                            Attribute::string("health", "healthy"),
+                        ],
+                    );
                     let mut lock = status.lock();
                     lock.loaded = true;
                     lock.health = PluginHostHealth::Healthy;
@@ -253,6 +321,24 @@ fn run_worker(
                     let _ = result_tx.try_send(samples);
                 }
                 Err(error) => {
+                    let elapsed_ms = process_started
+                        .elapsed()
+                        .as_millis()
+                        .min(u128::from(u64::MAX)) as u64;
+                    telemetry.process_duration.record(
+                        elapsed_ms,
+                        &[
+                            Attribute::string("api", api_label),
+                            Attribute::string(
+                                "health",
+                                if error.is_timeout() {
+                                    "degraded"
+                                } else {
+                                    "failed"
+                                },
+                            ),
+                        ],
+                    );
                     failed = Some(error);
                 }
             }
@@ -261,9 +347,15 @@ fn run_worker(
         if let Some(error) = failed {
             let mut lock = status.lock();
             lock.error_count = lock.error_count.saturating_add(1);
+            telemetry
+                .error_count
+                .add(1, &[Attribute::string("api", api_label)]);
             if error.is_timeout() {
                 lock.timeout_count = lock.timeout_count.saturating_add(1);
                 lock.health = PluginHostHealth::Degraded;
+                telemetry
+                    .timeout_count
+                    .add(1, &[Attribute::string("api", api_label)]);
             } else {
                 lock.health = PluginHostHealth::Failed;
             }
@@ -271,6 +363,9 @@ fn run_worker(
             lock.host_pid = None;
             lock.last_error = Some(error.message());
             lock.restart_count = lock.restart_count.saturating_add(1);
+            telemetry
+                .restart_count
+                .add(1, &[Attribute::string("api", api_label)]);
             drop(lock);
 
             if let Some(mut current) = session.take() {

--- a/crates/mars-ipc/Cargo.toml
+++ b/crates/mars-ipc/Cargo.toml
@@ -10,9 +10,14 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = []
+otel = ["mars-telemetry/otel"]
+
 [dependencies]
 async-trait.workspace = true
 mars-types = { path = "../mars-types" }
+mars-telemetry = { path = "../mars-telemetry" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/mars-ipc/src/lib.rs
+++ b/crates/mars-ipc/src/lib.rs
@@ -3,9 +3,12 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::Duration;
+use std::time::Instant;
 
 use async_trait::async_trait;
+use mars_telemetry::{Attribute, TelemetryTracer, U64Counter, U64Histogram};
 use mars_types::{
     ApplyPlan, ApplyRequest, ApplyResult, CaptureProcessInfo, ClearRequest, DaemonStatus,
     DeviceInventory, DoctorReport, ExitCode, PlanRequest, ValidateRequest, ValidationReport,
@@ -20,6 +23,46 @@ use tracing::{debug, warn};
 use uuid::Uuid;
 
 pub const PROTOCOL_VERSION: u16 = 2;
+
+#[derive(Debug)]
+struct IpcTelemetry {
+    tracer: TelemetryTracer,
+    client_request_count: U64Counter,
+    client_request_duration: U64Histogram,
+    daemon_request_count: U64Counter,
+    daemon_request_duration: U64Histogram,
+}
+
+static IPC_TELEMETRY: OnceLock<IpcTelemetry> = OnceLock::new();
+
+fn ipc_telemetry() -> &'static IpcTelemetry {
+    IPC_TELEMETRY.get_or_init(|| {
+        let meter = mars_telemetry::global_meter("mars-ipc");
+        IpcTelemetry {
+            tracer: mars_telemetry::global_tracer("mars-ipc"),
+            client_request_count: meter.u64_counter(
+                "mars.ipc.request.count",
+                "Count of IPC client requests",
+                "{request}",
+            ),
+            client_request_duration: meter.u64_histogram(
+                "mars.ipc.request.duration",
+                "Duration of IPC client requests",
+                "ms",
+            ),
+            daemon_request_count: meter.u64_counter(
+                "mars.daemon.request.count",
+                "Count of daemon requests",
+                "{request}",
+            ),
+            daemon_request_duration: meter.u64_histogram(
+                "mars.daemon.request.duration",
+                "Duration of daemon requests",
+                "ms",
+            ),
+        }
+    })
+}
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -233,6 +276,7 @@ impl IpcClient {
 
     pub async fn send(&self, request: DaemonRequest) -> Result<DaemonResponse, IpcError> {
         let command = request.command();
+        let command_name = command_label(command);
         let payload = request.into_payload()?;
         let envelope = RequestEnvelope {
             protocol_version: PROTOCOL_VERSION,
@@ -240,46 +284,79 @@ impl IpcClient {
             command,
             payload,
         };
+        let request_id = envelope.request_id.clone();
+        let timeout_ms = self.timeout.as_millis().min(u128::from(u64::MAX)) as u64;
+        let telemetry = ipc_telemetry();
+        let mut span = telemetry.tracer.start_span(
+            "mars.ipc.client.request",
+            &[
+                Attribute::string("command", command_name),
+                Attribute::string("request_id", request_id.clone()),
+                Attribute::u64("timeout_ms", timeout_ms),
+            ],
+        );
+        let started = Instant::now();
 
-        let stream = UnixStream::connect(&self.socket_path).await?;
-        let (reader, mut writer) = stream.into_split();
-        let encoded = serde_json::to_string(&envelope).map_err(IpcError::SerdeJson)?;
-        writer.write_all(encoded.as_bytes()).await?;
-        writer.write_all(b"\n").await?;
-        writer.flush().await?;
+        let outcome: Result<DaemonResponse, IpcError> = async {
+            let stream = UnixStream::connect(&self.socket_path).await?;
+            let (reader, mut writer) = stream.into_split();
+            let encoded = serde_json::to_string(&envelope).map_err(IpcError::SerdeJson)?;
+            writer.write_all(encoded.as_bytes()).await?;
+            writer.write_all(b"\n").await?;
+            writer.flush().await?;
 
-        let mut lines = BufReader::new(reader).lines();
-        let maybe_line = timeout(self.timeout, lines.next_line())
-            .await
-            .map_err(|_| IpcError::Timeout)??;
-        let Some(line) = maybe_line else {
-            return Err(IpcError::Io(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                "daemon closed connection",
-            )));
-        };
+            let mut lines = BufReader::new(reader).lines();
+            let maybe_line = timeout(self.timeout, lines.next_line())
+                .await
+                .map_err(|_| IpcError::Timeout)??;
+            let Some(line) = maybe_line else {
+                return Err(IpcError::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "daemon closed connection",
+                )));
+            };
 
-        let response: ResponseEnvelope =
-            serde_json::from_str(&line).map_err(IpcError::SerdeJson)?;
-        if response.protocol_version != PROTOCOL_VERSION {
-            return Err(IpcError::ProtocolVersionMismatch {
-                expected: PROTOCOL_VERSION,
-                actual: response.protocol_version,
-            });
+            let response: ResponseEnvelope =
+                serde_json::from_str(&line).map_err(IpcError::SerdeJson)?;
+            if response.protocol_version != PROTOCOL_VERSION {
+                return Err(IpcError::ProtocolVersionMismatch {
+                    expected: PROTOCOL_VERSION,
+                    actual: response.protocol_version,
+                });
+            }
+
+            if !response.ok {
+                return Err(IpcError::DaemonError {
+                    message: response
+                        .error
+                        .unwrap_or_else(|| "unknown daemon error".to_string()),
+                    exit_code: response
+                        .exit_code
+                        .and_then(|code| ExitCode::try_from(code).ok()),
+                });
+            }
+
+            DaemonResponse::from_payload(response.command, response.payload)
         }
+        .await;
 
-        if !response.ok {
-            return Err(IpcError::DaemonError {
-                message: response
-                    .error
-                    .unwrap_or_else(|| "unknown daemon error".to_string()),
-                exit_code: response
-                    .exit_code
-                    .and_then(|code| ExitCode::try_from(code).ok()),
-            });
+        let elapsed_ms = started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+        let success = outcome.is_ok();
+        let attrs = [
+            Attribute::string("command", command_name),
+            Attribute::bool("success", success),
+        ];
+        telemetry.client_request_count.add(1, &attrs);
+        telemetry.client_request_duration.record(elapsed_ms, &attrs);
+        span.set_attributes(&attrs);
+        if let Err(error) = outcome.as_ref() {
+            span.set_status_error(error.to_string());
+        } else {
+            span.set_status_ok();
         }
+        span.end();
 
-        DaemonResponse::from_payload(response.command, response.payload)
+        outcome
     }
 }
 
@@ -320,6 +397,7 @@ where
 {
     let (reader, mut writer) = stream.into_split();
     let mut lines = BufReader::new(reader).lines();
+    let telemetry = ipc_telemetry();
 
     while let Some(line) = lines.next_line().await? {
         if line.trim().is_empty() {
@@ -327,8 +405,19 @@ where
         }
 
         let envelope: RequestEnvelope = serde_json::from_str(&line).map_err(IpcError::SerdeJson)?;
-        if envelope.protocol_version != PROTOCOL_VERSION {
-            let response = ResponseEnvelope {
+        let command_name = command_label(envelope.command);
+        let request_id = envelope.request_id.clone();
+        let mut span = telemetry.tracer.start_span(
+            "mars.daemon.request",
+            &[
+                Attribute::string("command", command_name),
+                Attribute::string("request_id", request_id),
+            ],
+        );
+        let started = Instant::now();
+
+        let response = if envelope.protocol_version != PROTOCOL_VERSION {
+            ResponseEnvelope {
                 protocol_version: PROTOCOL_VERSION,
                 request_id: envelope.request_id,
                 command: envelope.command,
@@ -339,22 +428,29 @@ where
                     PROTOCOL_VERSION, envelope.protocol_version
                 )),
                 exit_code: Some(ExitCode::DaemonCommunication.as_i32()),
-            };
-            write_response(&mut writer, &response).await?;
-            continue;
-        }
-
-        let request = deserialize_request(envelope.command, envelope.payload);
-        let response = match request {
-            Ok(request) => match handler.handle(request).await {
-                Ok(payload) => ResponseEnvelope {
-                    protocol_version: PROTOCOL_VERSION,
-                    request_id: envelope.request_id,
-                    command: envelope.command,
-                    ok: true,
-                    payload: payload.into_payload()?,
-                    error: None,
-                    exit_code: None,
+            }
+        } else {
+            let request = deserialize_request(envelope.command, envelope.payload);
+            match request {
+                Ok(request) => match handler.handle(request).await {
+                    Ok(payload) => ResponseEnvelope {
+                        protocol_version: PROTOCOL_VERSION,
+                        request_id: envelope.request_id,
+                        command: envelope.command,
+                        ok: true,
+                        payload: payload.into_payload()?,
+                        error: None,
+                        exit_code: None,
+                    },
+                    Err(error) => ResponseEnvelope {
+                        protocol_version: PROTOCOL_VERSION,
+                        request_id: envelope.request_id,
+                        command: envelope.command,
+                        ok: false,
+                        payload: Value::Null,
+                        error: Some(error.message),
+                        exit_code: Some(error.exit_code.as_i32()),
+                    },
                 },
                 Err(error) => ResponseEnvelope {
                     protocol_version: PROTOCOL_VERSION,
@@ -362,21 +458,32 @@ where
                     command: envelope.command,
                     ok: false,
                     payload: Value::Null,
-                    error: Some(error.message),
-                    exit_code: Some(error.exit_code.as_i32()),
+                    error: Some(error.to_string()),
+                    exit_code: Some(ExitCode::InvalidInput.as_i32()),
                 },
-            },
-            Err(error) => ResponseEnvelope {
-                protocol_version: PROTOCOL_VERSION,
-                request_id: envelope.request_id,
-                command: envelope.command,
-                ok: false,
-                payload: Value::Null,
-                error: Some(error.to_string()),
-                exit_code: Some(ExitCode::InvalidInput.as_i32()),
-            },
+            }
         };
 
+        let elapsed_ms = started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+        let attrs = [
+            Attribute::string("command", command_name),
+            Attribute::bool("success", response.ok),
+            Attribute::i64("exit_code", i64::from(response.exit_code.unwrap_or(0))),
+        ];
+        telemetry.daemon_request_count.add(1, &attrs);
+        telemetry.daemon_request_duration.record(elapsed_ms, &attrs);
+        span.set_attributes(&attrs);
+        if response.ok {
+            span.set_status_ok();
+        } else {
+            span.set_status_error(
+                response
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "unknown daemon error".to_string()),
+            );
+        }
+        span.end();
         write_response(&mut writer, &response).await?;
     }
 
@@ -417,6 +524,21 @@ async fn write_response(
     writer.write_all(b"\n").await?;
     writer.flush().await?;
     Ok(())
+}
+
+const fn command_label(command: Command) -> &'static str {
+    match command {
+        Command::Ping => "ping",
+        Command::Validate => "validate",
+        Command::Plan => "plan",
+        Command::Apply => "apply",
+        Command::Clear => "clear",
+        Command::Status => "status",
+        Command::Devices => "devices",
+        Command::Processes => "processes",
+        Command::Logs => "logs",
+        Command::Doctor => "doctor",
+    }
 }
 
 #[cfg(test)]

--- a/crates/mars-plugin-host/Cargo.toml
+++ b/crates/mars-plugin-host/Cargo.toml
@@ -10,7 +10,12 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = []
+otel = ["mars-telemetry/otel"]
+
 [dependencies]
+mars-telemetry = { path = "../mars-telemetry" }
 mars-types = { path = "../mars-types" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mars-plugin-host/src/main.rs
+++ b/crates/mars-plugin-host/src/main.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
 
+use mars_telemetry::{ServiceIdentity, TelemetryRuntime};
 use mars_types::{
     AuPluginConfig, PLUGIN_HOST_PROTOCOL_VERSION, PluginHostRequest, PluginHostResponse,
 };
@@ -241,8 +242,19 @@ fn run_server(socket_path: PathBuf) -> Result<(), String> {
 }
 
 fn main() {
-    let exit = match parse_socket_path().and_then(run_server) {
-        Ok(()) => 0,
+    let telemetry_runtime = TelemetryRuntime::init(ServiceIdentity::new(
+        "mars-plugin-host",
+        env!("CARGO_PKG_VERSION"),
+        "plugin_host",
+    ));
+    let exit = match telemetry_runtime {
+        Ok(_runtime) => match parse_socket_path().and_then(run_server) {
+            Ok(()) => 0,
+            Err(error) => {
+                eprintln!("{error}");
+                1
+            }
+        },
         Err(error) => {
             eprintln!("{error}");
             1

--- a/crates/mars-telemetry/Cargo.toml
+++ b/crates/mars-telemetry/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "mars-telemetry"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = []
+otel = [
+  "dep:opentelemetry",
+  "dep:opentelemetry_sdk",
+  "dep:opentelemetry-otlp",
+]
+
+[dependencies]
+thiserror.workspace = true
+uuid.workspace = true
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }

--- a/crates/mars-telemetry/src/lib.rs
+++ b/crates/mars-telemetry/src/lib.rs
@@ -1,0 +1,641 @@
+#![forbid(unsafe_code)]
+
+use std::env;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use thiserror::Error;
+
+#[cfg(feature = "otel")]
+use opentelemetry::trace::Span as _;
+#[cfg(feature = "otel")]
+use opentelemetry_otlp::WithExportConfig;
+
+pub const TELEMETRY_MODE_ENV: &str = "MARS_OTEL_MODE";
+pub const OTEL_ENDPOINT_ENV: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
+
+static TELEMETRY_ENABLED: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TelemetryMode {
+    Off,
+    Required,
+}
+
+impl TelemetryMode {
+    fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "off" => Some(Self::Off),
+            "required" => Some(Self::Required),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum TelemetryError {
+    #[error("invalid telemetry mode '{value}': expected 'off' or 'required'")]
+    InvalidMode { value: String },
+    #[error("telemetry mode 'required' is not available: binary is built without 'otel' feature")]
+    RequiredUnavailable,
+    #[error("telemetry mode 'required' requires {0} to be set")]
+    MissingRequiredEnv(&'static str),
+    #[cfg(feature = "otel")]
+    #[error("failed to build OTLP trace exporter: {0}")]
+    TraceExporter(String),
+    #[cfg(feature = "otel")]
+    #[error("failed to build OTLP metrics exporter: {0}")]
+    MetricsExporter(String),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ServiceIdentity {
+    pub service_name: &'static str,
+    pub service_version: &'static str,
+    pub component: &'static str,
+}
+
+impl ServiceIdentity {
+    #[must_use]
+    pub const fn new(
+        service_name: &'static str,
+        service_version: &'static str,
+        component: &'static str,
+    ) -> Self {
+        Self {
+            service_name,
+            service_version,
+            component,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(not(feature = "otel"), allow(dead_code))]
+pub struct Attribute {
+    key: &'static str,
+    value: AttributeValue,
+}
+
+impl Attribute {
+    #[must_use]
+    pub fn string(key: &'static str, value: impl Into<String>) -> Self {
+        Self {
+            key,
+            value: AttributeValue::String(value.into()),
+        }
+    }
+
+    #[must_use]
+    pub const fn bool(key: &'static str, value: bool) -> Self {
+        Self {
+            key,
+            value: AttributeValue::Bool(value),
+        }
+    }
+
+    #[must_use]
+    pub const fn u64(key: &'static str, value: u64) -> Self {
+        Self {
+            key,
+            value: AttributeValue::U64(value),
+        }
+    }
+
+    #[must_use]
+    pub const fn i64(key: &'static str, value: i64) -> Self {
+        Self {
+            key,
+            value: AttributeValue::I64(value),
+        }
+    }
+
+    #[must_use]
+    pub const fn f64(key: &'static str, value: f64) -> Self {
+        Self {
+            key,
+            value: AttributeValue::F64(value),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(not(feature = "otel"), allow(dead_code))]
+enum AttributeValue {
+    String(String),
+    Bool(bool),
+    U64(u64),
+    I64(i64),
+    F64(f64),
+}
+
+#[derive(Debug)]
+pub struct TelemetryRuntime {
+    enabled: bool,
+    #[cfg(feature = "otel")]
+    tracer_provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+    #[cfg(feature = "otel")]
+    meter_provider: Option<opentelemetry_sdk::metrics::SdkMeterProvider>,
+}
+
+impl TelemetryRuntime {
+    pub fn init(identity: ServiceIdentity) -> Result<Self, TelemetryError> {
+        let mode = telemetry_mode_from_env()?;
+
+        #[cfg(not(feature = "otel"))]
+        {
+            let _ = identity;
+            if mode == TelemetryMode::Required {
+                return Err(TelemetryError::RequiredUnavailable);
+            }
+
+            TELEMETRY_ENABLED.store(false, Ordering::Relaxed);
+            return Ok(Self { enabled: false });
+        }
+
+        #[cfg(feature = "otel")]
+        {
+            if mode == TelemetryMode::Off {
+                TELEMETRY_ENABLED.store(false, Ordering::Relaxed);
+                return Ok(Self {
+                    enabled: false,
+                    tracer_provider: None,
+                    meter_provider: None,
+                });
+            }
+
+            let endpoint = env::var(OTEL_ENDPOINT_ENV)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .ok_or(TelemetryError::MissingRequiredEnv(OTEL_ENDPOINT_ENV))?;
+
+            use opentelemetry::KeyValue;
+
+            let resource = opentelemetry_sdk::Resource::builder_empty()
+                .with_attributes([
+                    KeyValue::new("service.name", identity.service_name),
+                    KeyValue::new("service.version", identity.service_version),
+                    KeyValue::new("service.instance.id", uuid::Uuid::new_v4().to_string()),
+                    KeyValue::new("mars.component", identity.component),
+                    KeyValue::new("os.type", std::env::consts::OS),
+                    KeyValue::new("host.arch", std::env::consts::ARCH),
+                ])
+                .build();
+
+            let trace_exporter = opentelemetry_otlp::SpanExporter::builder()
+                .with_tonic()
+                .with_endpoint(endpoint.clone())
+                .build()
+                .map_err(|error| TelemetryError::TraceExporter(error.to_string()))?;
+
+            let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+                .with_resource(resource.clone())
+                .with_batch_exporter(trace_exporter)
+                .build();
+            opentelemetry::global::set_tracer_provider(tracer_provider.clone());
+
+            let metrics_exporter = opentelemetry_otlp::MetricExporter::builder()
+                .with_tonic()
+                .with_endpoint(endpoint)
+                .build()
+                .map_err(|error| TelemetryError::MetricsExporter(error.to_string()))?;
+
+            let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+                .with_resource(resource)
+                .with_periodic_exporter(metrics_exporter)
+                .build();
+            opentelemetry::global::set_meter_provider(meter_provider.clone());
+
+            TELEMETRY_ENABLED.store(true, Ordering::Relaxed);
+            Ok(Self {
+                enabled: true,
+                tracer_provider: Some(tracer_provider),
+                meter_provider: Some(meter_provider),
+            })
+        }
+    }
+
+    #[must_use]
+    pub const fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    #[must_use]
+    pub fn tracer(&self, scope: &'static str) -> TelemetryTracer {
+        if !self.enabled {
+            return TelemetryTracer::disabled();
+        }
+        TelemetryTracer::enabled(scope)
+    }
+
+    #[must_use]
+    pub fn meter(&self, scope: &'static str) -> TelemetryMeter {
+        if !self.enabled {
+            return TelemetryMeter::disabled();
+        }
+        TelemetryMeter::enabled(scope)
+    }
+}
+
+impl Drop for TelemetryRuntime {
+    fn drop(&mut self) {
+        #[cfg(feature = "otel")]
+        {
+            if let Some(meter_provider) = self.meter_provider.take() {
+                let _ = meter_provider.shutdown();
+            }
+            if let Some(tracer_provider) = self.tracer_provider.take() {
+                let _ = tracer_provider.shutdown();
+            }
+        }
+        TELEMETRY_ENABLED.store(false, Ordering::Relaxed);
+    }
+}
+
+#[must_use]
+pub fn telemetry_enabled() -> bool {
+    TELEMETRY_ENABLED.load(Ordering::Relaxed)
+}
+
+#[must_use]
+pub fn global_tracer(scope: &'static str) -> TelemetryTracer {
+    if telemetry_enabled() {
+        TelemetryTracer::enabled(scope)
+    } else {
+        TelemetryTracer::disabled()
+    }
+}
+
+#[must_use]
+pub fn global_meter(scope: &'static str) -> TelemetryMeter {
+    if telemetry_enabled() {
+        TelemetryMeter::enabled(scope)
+    } else {
+        TelemetryMeter::disabled()
+    }
+}
+
+pub fn telemetry_mode_from_env() -> Result<TelemetryMode, TelemetryError> {
+    match env::var(TELEMETRY_MODE_ENV) {
+        Ok(raw) => {
+            TelemetryMode::parse(raw.trim()).ok_or(TelemetryError::InvalidMode { value: raw })
+        }
+        Err(env::VarError::NotPresent) => Ok(TelemetryMode::Off),
+        Err(env::VarError::NotUnicode(_)) => Err(TelemetryError::InvalidMode {
+            value: "<non-unicode>".to_string(),
+        }),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TelemetryTracer {
+    #[cfg(feature = "otel")]
+    scope: Option<&'static str>,
+}
+
+impl TelemetryTracer {
+    fn disabled() -> Self {
+        Self {
+            #[cfg(feature = "otel")]
+            scope: None,
+        }
+    }
+
+    fn enabled(_scope: &'static str) -> Self {
+        Self {
+            #[cfg(feature = "otel")]
+            scope: Some(_scope),
+        }
+    }
+
+    #[must_use]
+    pub fn start_span(&self, name: &'static str, attrs: &[Attribute]) -> SpanGuard {
+        #[cfg(feature = "otel")]
+        {
+            if let Some(scope) = self.scope {
+                use opentelemetry::trace::{TraceContextExt, Tracer};
+
+                let tracer = opentelemetry::global::tracer(scope);
+                let mut span = tracer.start(name);
+                span.set_attributes(to_key_values(attrs));
+                let cx = opentelemetry::Context::current_with_span(span);
+                return SpanGuard { context: Some(cx) };
+            }
+        }
+
+        let _ = (name, attrs);
+        SpanGuard::disabled()
+    }
+
+    #[must_use]
+    pub fn start_child_span(
+        &self,
+        parent: &SpanGuard,
+        name: &'static str,
+        attrs: &[Attribute],
+    ) -> SpanGuard {
+        #[cfg(feature = "otel")]
+        {
+            if let (Some(scope), Some(parent_context)) = (self.scope, parent.context.as_ref()) {
+                use opentelemetry::trace::{TraceContextExt, Tracer};
+
+                let tracer = opentelemetry::global::tracer(scope);
+                let mut span = tracer.start_with_context(name, parent_context);
+                span.set_attributes(to_key_values(attrs));
+                let cx = opentelemetry::Context::current_with_span(span);
+                return SpanGuard { context: Some(cx) };
+            }
+        }
+
+        let _ = (parent, name, attrs);
+        SpanGuard::disabled()
+    }
+}
+
+#[derive(Debug)]
+pub struct SpanGuard {
+    #[cfg(feature = "otel")]
+    context: Option<opentelemetry::Context>,
+}
+
+impl SpanGuard {
+    fn disabled() -> Self {
+        Self {
+            #[cfg(feature = "otel")]
+            context: None,
+        }
+    }
+
+    pub fn set_attributes(&self, attrs: &[Attribute]) {
+        #[cfg(feature = "otel")]
+        {
+            use opentelemetry::trace::TraceContextExt;
+
+            if let Some(context) = self.context.as_ref() {
+                context.span().set_attributes(to_key_values(attrs));
+            }
+        }
+
+        let _ = attrs;
+    }
+
+    pub fn set_status_ok(&self) {
+        #[cfg(feature = "otel")]
+        {
+            use opentelemetry::trace::{Status, TraceContextExt};
+
+            if let Some(context) = self.context.as_ref() {
+                context.span().set_status(Status::Ok);
+            }
+        }
+    }
+
+    pub fn set_status_error(&self, description: impl Into<String>) {
+        #[cfg(feature = "otel")]
+        {
+            use opentelemetry::trace::{Status, TraceContextExt};
+
+            if let Some(context) = self.context.as_ref() {
+                context.span().set_status(Status::Error {
+                    description: description.into().into(),
+                });
+            }
+        }
+
+        #[cfg(not(feature = "otel"))]
+        {
+            let _ = description.into();
+        }
+    }
+
+    pub fn end(&mut self) {
+        #[cfg(feature = "otel")]
+        {
+            use opentelemetry::trace::TraceContextExt;
+
+            if let Some(context) = self.context.take() {
+                context.span().end();
+            }
+        }
+    }
+}
+
+impl Drop for SpanGuard {
+    fn drop(&mut self) {
+        self.end();
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TelemetryMeter {
+    #[cfg(feature = "otel")]
+    meter: Option<opentelemetry::metrics::Meter>,
+}
+
+impl TelemetryMeter {
+    fn disabled() -> Self {
+        Self {
+            #[cfg(feature = "otel")]
+            meter: None,
+        }
+    }
+
+    fn enabled(_scope: &'static str) -> Self {
+        Self {
+            #[cfg(feature = "otel")]
+            meter: Some(opentelemetry::global::meter(_scope)),
+        }
+    }
+
+    #[must_use]
+    pub fn u64_counter(
+        &self,
+        name: &'static str,
+        description: &'static str,
+        unit: &'static str,
+    ) -> U64Counter {
+        #[cfg(feature = "otel")]
+        {
+            if let Some(meter) = self.meter.as_ref() {
+                let counter = meter
+                    .u64_counter(name)
+                    .with_description(description)
+                    .with_unit(unit)
+                    .build();
+                return U64Counter {
+                    counter: Some(counter),
+                };
+            }
+        }
+
+        let _ = (name, description, unit);
+        U64Counter::disabled()
+    }
+
+    #[must_use]
+    pub fn u64_histogram(
+        &self,
+        name: &'static str,
+        description: &'static str,
+        unit: &'static str,
+    ) -> U64Histogram {
+        #[cfg(feature = "otel")]
+        {
+            if let Some(meter) = self.meter.as_ref() {
+                let histogram = meter
+                    .u64_histogram(name)
+                    .with_description(description)
+                    .with_unit(unit)
+                    .build();
+                return U64Histogram {
+                    histogram: Some(histogram),
+                };
+            }
+        }
+
+        let _ = (name, description, unit);
+        U64Histogram::disabled()
+    }
+
+    #[must_use]
+    pub fn f64_histogram(
+        &self,
+        name: &'static str,
+        description: &'static str,
+        unit: &'static str,
+    ) -> F64Histogram {
+        #[cfg(feature = "otel")]
+        {
+            if let Some(meter) = self.meter.as_ref() {
+                let histogram = meter
+                    .f64_histogram(name)
+                    .with_description(description)
+                    .with_unit(unit)
+                    .build();
+                return F64Histogram {
+                    histogram: Some(histogram),
+                };
+            }
+        }
+
+        let _ = (name, description, unit);
+        F64Histogram::disabled()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct U64Counter {
+    #[cfg(feature = "otel")]
+    counter: Option<opentelemetry::metrics::Counter<u64>>,
+}
+
+impl U64Counter {
+    fn disabled() -> Self {
+        Self {
+            #[cfg(feature = "otel")]
+            counter: None,
+        }
+    }
+
+    pub fn add(&self, value: u64, attrs: &[Attribute]) {
+        #[cfg(feature = "otel")]
+        {
+            if let Some(counter) = self.counter.as_ref() {
+                counter.add(value, &to_key_values(attrs));
+                return;
+            }
+        }
+
+        let _ = (value, attrs);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct U64Histogram {
+    #[cfg(feature = "otel")]
+    histogram: Option<opentelemetry::metrics::Histogram<u64>>,
+}
+
+impl U64Histogram {
+    fn disabled() -> Self {
+        Self {
+            #[cfg(feature = "otel")]
+            histogram: None,
+        }
+    }
+
+    pub fn record(&self, value: u64, attrs: &[Attribute]) {
+        #[cfg(feature = "otel")]
+        {
+            if let Some(histogram) = self.histogram.as_ref() {
+                histogram.record(value, &to_key_values(attrs));
+                return;
+            }
+        }
+
+        let _ = (value, attrs);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct F64Histogram {
+    #[cfg(feature = "otel")]
+    histogram: Option<opentelemetry::metrics::Histogram<f64>>,
+}
+
+impl F64Histogram {
+    fn disabled() -> Self {
+        Self {
+            #[cfg(feature = "otel")]
+            histogram: None,
+        }
+    }
+
+    pub fn record(&self, value: f64, attrs: &[Attribute]) {
+        #[cfg(feature = "otel")]
+        {
+            if let Some(histogram) = self.histogram.as_ref() {
+                histogram.record(value, &to_key_values(attrs));
+                return;
+            }
+        }
+
+        let _ = (value, attrs);
+    }
+}
+
+#[cfg(feature = "otel")]
+fn to_key_values(attrs: &[Attribute]) -> Vec<opentelemetry::KeyValue> {
+    attrs
+        .iter()
+        .map(|attr| {
+            let value = match &attr.value {
+                AttributeValue::String(value) => opentelemetry::Value::from(value.clone()),
+                AttributeValue::Bool(value) => opentelemetry::Value::from(*value),
+                AttributeValue::U64(value) => opentelemetry::Value::from(*value as i64),
+                AttributeValue::I64(value) => opentelemetry::Value::from(*value),
+                AttributeValue::F64(value) => opentelemetry::Value::from(*value),
+            };
+            opentelemetry::KeyValue::new(attr.key, value)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TelemetryMode;
+
+    #[test]
+    fn parser_accepts_supported_modes() {
+        assert_eq!(TelemetryMode::parse("off"), Some(TelemetryMode::Off));
+        assert_eq!(
+            TelemetryMode::parse("required"),
+            Some(TelemetryMode::Required)
+        );
+    }
+
+    #[test]
+    fn parser_rejects_invalid_mode() {
+        assert!(TelemetryMode::parse("auto").is_none());
+        assert!(TelemetryMode::parse("OFF").is_none());
+    }
+}

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -43,6 +43,14 @@ All active profiles must use `version: 2` (v1 is rejected).
   - `sinks.streams` is currently descriptor-only; runtime marks stream sinks as failed with `last_error`.
 - `external_runtime.stream_errors` is capped (ring buffer) to avoid unbounded growth.
 
+## Optional telemetry (OTel)
+
+- Telemetry is opt-in and off by default.
+- Set `MARS_OTEL_MODE=required` to require telemetry initialization at startup.
+- Set `OTEL_EXPORTER_OTLP_ENDPOINT` when `MARS_OTEL_MODE=required`.
+- Build telemetry-enabled binaries with `cargo build --workspace --features otel`.
+- Full metric/span reference: `docs/telemetry.md`.
+
 ## Log cursor semantics
 
 - `mars logs` / daemon `LogResponse.next_cursor` now represent a byte offset in `marsd.log`.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,90 @@
+# MARS Telemetry (Optional OpenTelemetry)
+
+MARS supports optional OpenTelemetry (OTLP) export for usage, reliability, and realtime performance analysis.
+
+## Enablement model
+
+Telemetry mode is controlled by `MARS_OTEL_MODE`:
+
+- `off` (default): telemetry is disabled, no OTLP providers are initialized.
+- `required`: telemetry must initialize successfully; process startup fails fast on configuration/init errors.
+
+When `required` mode is used, `OTEL_EXPORTER_OTLP_ENDPOINT` must be set.
+
+## Build with telemetry
+
+Telemetry code paths are behind the crate feature `otel`.
+
+```bash
+cargo build --workspace --features otel
+```
+
+## Runtime configuration
+
+Example:
+
+```bash
+export MARS_OTEL_MODE=required
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
+```
+
+Then run normal commands/binaries (`mars`, `marsd`, `mars-plugin-host`).
+
+## Traces
+
+- `mars.cli.command`
+- `mars.ipc.client.request`
+- `mars.daemon.request`
+- `mars.apply.transaction`
+- `mars.apply.stage.profile_validate`
+- `mars.apply.stage.plan`
+- `mars.apply.stage.external_resolve`
+- `mars.apply.stage.driver_compatibility`
+- `mars.apply.stage.driver_stage`
+- `mars.apply.stage.graph_activate`
+- `mars.apply.stage.capture_sync`
+- `mars.apply.stage.render_sync`
+- `mars.apply.stage.runtime_ready`
+
+## Metrics
+
+Control plane:
+
+- `mars.cli.command.count`
+- `mars.cli.command.duration`
+- `mars.ipc.request.count`
+- `mars.ipc.request.duration`
+- `mars.daemon.request.count`
+- `mars.daemon.request.duration`
+- `mars.apply.count`
+- `mars.apply.duration`
+- `mars.apply.stage.duration`
+- `mars.apply.rollback.count`
+
+Realtime/runtime snapshots:
+
+- `mars.render.cycle.duration`
+- `mars.render.cycle.budget_utilization`
+- `mars.render.deadline_miss.count`
+- `mars.render.xrun.count`
+- `mars.external.underrun.count`
+- `mars.external.overrun.count`
+- `mars.sink.drop.count`
+- `mars.sink.write_error.count`
+- `mars.capture.tap.active`
+- `mars.capture.tap.failed`
+- `mars.plugin.process.duration`
+- `mars.plugin.timeout.count`
+- `mars.plugin.error.count`
+- `mars.plugin.restart.count`
+
+## Privacy and cardinality
+
+Telemetry intentionally does not export audio payload or raw high-cardinality identifiers such as:
+
+- profile file paths
+- sink file paths
+- raw device UIDs
+- process bundle IDs
+
+Use bounded attributes (command/stage/success/sample_rate/buffer_frames/api) for stable dashboards.


### PR DESCRIPTION
## Summary
- add a new `mars-telemetry` crate with feature-gated OTel support (`otel`) and strict runtime gating via `MARS_OTEL_MODE=off|required`
- initialize telemetry in `mars`, `marsd`, and `mars-plugin-host`, with fail-fast behavior in `required` mode
- instrument control plane paths:
  - `mars.cli.command` span + `mars.cli.command.count` / `mars.cli.command.duration`
  - `mars.ipc.client.request` span + `mars.ipc.request.*`
  - `mars.daemon.request` span + `mars.daemon.request.*`
- instrument daemon apply transaction with stage spans and metrics:
  - `mars.apply.transaction`
  - `mars.apply.stage.*`
  - `mars.apply.count`, `mars.apply.duration`, `mars.apply.stage.duration`, `mars.apply.rollback.count`
- add a daemon non-RT telemetry reporter thread that exports runtime counters and sampled render health metrics (deadline misses, xruns, underrun/overrun, sink/capture/plugin runtime counters)
- instrument plugin host processing path in `mars-engine` (`au_host`) for process duration/timeout/error/restart metrics
- document setup and metric/span dictionary in `docs/telemetry.md`, and link from README/operator guide

## Validation
- `cargo check --workspace`
- `cargo check --workspace --features otel`
- `cargo test -p mars-telemetry`
- `cargo test -p mars-ipc`
- `cargo test -p mars-ipc --features otel`
- `cargo test -p mars-engine --features otel --lib`
- `cargo test -p mars-cli`
- `cargo test -p mars-cli --features otel`
- `cargo test -p mars-daemon --lib`
- `cargo test -p mars-daemon --features otel --lib`

Closes #32
